### PR TITLE
docs: signale le cadre fictif du projet, copyright à Azélie Bernard

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Niamato Consulting (Azélie Bernard & Sébastien Lazcanotegui)
+Copyright (c) 2026 Azélie Bernard
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # ThumaCheck — Social Media Intelligence & AI Monitor
 
-> **Built by [Niamato Consulting](https://github.com/azelbanks/thumacheck) (Azélie Bernard & Sébastien Lazcanotegui) for [Thumalien](https://thumalien.com), a fact-checking and media monitoring company.**
+> ### 📌 Cadre du projet
+>
+> **Thumalien** (le client), **Niamato Consulting** (l'agence) et **Sébastien
+> Lazcanotegui** (le co-auteur) sont des **entités fictives**. Elles constituent
+> une mise en situation professionnelle qui structure le projet : cahier des
+> charges, conformité RGPD, planification, répartition des rôles.
+>
+> **ThumaCheck est un projet personnel d'[Azélie Bernard](https://github.com/azelbanks).**
+> Le scénario est fictif ; tout le reste est réel — le code, les modèles
+> entraînés, les données collectées sur Bluesky, les métriques mesurées et les
+> analyses.
+
+> **Built by Niamato Consulting (Azélie Bernard & Sébastien Lazcanotegui) for Thumalien, a fact-checking and media monitoring company.** *(mise en situation — voir l'encadré ci-dessus)*
 
 ![CI](https://github.com/azelbanks/thumacheck/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
@@ -425,6 +437,10 @@ This project was developed as a two-person team. Here is my specific scope:
 - **Green IT**: CodeCarbon integration and carbon footprint tracking
 
 Sébastien Lazcanotegui contributed to: RoBERTa EN fine-tuning, Bluesky data collection infrastructure, Kafka scalability prototype, and deployment configuration.
+
+> *Rappel : Sébastien Lazcanotegui est un co-auteur fictif de la mise en
+> situation (voir l'encadré en tête de README). L'ensemble du travail est
+> d'Azélie Bernard.*
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,7 @@
 **N'ouvrez pas d'issue publique pour une vulnérabilité.**
 
 Utilisez l'onglet *Security → Report a vulnerability* du dépôt (GitHub Private
-Vulnerability Reporting), ou écrivez à l'adresse de contact de Niamato
-Consulting.
+Vulnerability Reporting).
 
 Merci d'inclure : la version concernée, les étapes de reproduction, l'impact
 estimé et, si vous en avez un, un correctif proposé.


### PR DESCRIPTION
## Contexte

Thumalien (client), Niamato Consulting (agence) et Sébastien Lazcanotegui (co-auteur) sont des **entités fictives**.

Sur un dépôt public, la formulation d'origine se lisait comme une prestation commerciale réelle — lien vers un domaine externe compris. Un lecteur en concluait qu'un client existant avait été livré.

## Approche

Le scénario est **conservé** : il structure le cahier des charges, l'analyse RGPD, la planification et la répartition des rôles. Il est simplement annoncé comme tel.

- **Encadré en tête de README** distinguant ce qui est fictif (le cadre) de ce qui est réel : le code, les modèles entraînés, les données collectées sur Bluesky, les métriques mesurées, les analyses.
- **Rappel sous la section des contributions**, où des travaux précis (fine-tuning RoBERTa, collecte Bluesky, prototype Kafka) étaient attribués à un co-auteur fictif.
- **Lien vers `thumalien.com` retiré** : pointer vers un domaine externe tout en déclarant l'entité fictive serait contradictoire, et ce domaine peut appartenir à un tiers sans rapport.

## Autres fichiers

| Fichier | Modification |
|---|---|
| `LICENSE` | Copyright ramené à **Azélie Bernard** seule |
| `SECURITY.md` | Renvoi vers l'agence fictive supprimé — le signalement passe par GitHub Private Vulnerability Reporting |

Les 130 mentions de « Thumalien » dans les 65 fichiers de `docs/` sont **inchangées** : l'encadré du README couvre l'ensemble, et ces documents perdraient leur cohérence narrative si le client en était retiré.

## Vérifié

```
ruff check → All checks passed
mypy       → Success: no issues found in 33 source files
pytest     → 575 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)