### PR TITLE
feat: CD, endpoints d'exploitation et manifeste d'artefacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       # dans pyproject.toml pour la dette restante et la marche a suivre.
       - name: Type check
         run: mypy
+      # Detecte tout artefact de modele altere, supprime ou ajoute sans suivi.
+      - name: Verify model manifest
+        run: python scripts/models_manifest.py verify
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: release
+
+# Construit et publie l'image de l'API sur GitHub Container Registry.
+#
+# - push sur main  -> tags `main` et `sha-<court>` (deploiement continu)
+# - tag v*         -> tags semver (`v1.2.3`, `1.2`, `1`) + `latest`
+#
+# L'image porte GIT_SHA et BUILD_TIME, exposes par l'endpoint /version : c'est
+# ce qui permet de verifier qu'un deploiement ou un rollback a bien pris effet.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ github.event.repository.updated_at }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Verifie que l'image publiee demarre et se declare prete. Sans cette etape,
+  # une image cassee serait publiee sans que personne ne s'en apercoive avant
+  # le deploiement.
+  smoke-test:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start the published image
+        run: |
+          docker run -d --name thumacheck-api -p 8000:8000 \
+            -e GIT_SHA=${{ github.sha }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$(echo ${{ github.sha }} | cut -c1-7) \
+            uvicorn src.api.main:app --host 0.0.0.0 --port 8000
+
+      - name: Wait for /health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              echo "API en ligne apres ${i}0s"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::L'API n'a pas repondu sur /health en 300 s"
+          docker logs thumacheck-api
+          exit 1
+
+      - name: Check /version reports the deployed revision
+        run: |
+          set -o pipefail
+          got=$(curl -fsS http://localhost:8000/version | jq -r .git_sha)
+          echo "git_sha rapporte : $got"
+          [ "$got" = "${{ github.sha }}" ] || {
+            echo "::error::/version annonce $got au lieu de ${{ github.sha }}"
+            exit 1
+          }
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker logs thumacheck-api || true

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ data/*
 !models/*.pkl
 !models/*.joblib
 !models/config.json
+# Empreintes des artefacts, verifiees par la CI (scripts/models_manifest.py)
+!models/MANIFEST.json
 !config/search_config.json
 
 # Large model files (> 100MB, GitHub limit)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,26 @@
 # Image Python officielle légère
 FROM python:3.13-slim
 
+# Identite de la revision construite. Injectee par .github/workflows/release.yml
+# et exposee par l'endpoint /version : c'est ce qui permet de verifier qu'un
+# deploiement ou un rollback a bien pris effet.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=
+ENV GIT_SHA=${GIT_SHA} \
+    BUILD_TIME=${BUILD_TIME} \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
 # Dossier de travail dans le conteneur
 WORKDIR /app
 
 # --- CORRECTIF : Installation du compilateur GCC ---
 # Nécessaire pour wordcloud et autres librairies C
+# curl sert a la sonde de disponibilite (HEALTHCHECK).
 RUN apt-get update && apt-get install -y \
     gcc \
     build-essential \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copie des dépendances et installation
@@ -21,6 +33,12 @@ COPY . .
 # Creer un utilisateur non-root pour la securite
 RUN useradd -m -r appuser && chown -R appuser:appuser /app
 USER appuser
+
+# Sonde sur /ready et non /health : /health repond des que le processus vit,
+# /ready seulement quand le modele est charge et qu'une prediction est possible.
+# start-period couvre le chargement du modele au demarrage.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+    CMD curl -fsS http://localhost:8000/ready || exit 1
 
 # Commande par défaut : lancer le script de collecte
 CMD ["python", "src/collection/collect_bluesky.py"]

--- a/README.md
+++ b/README.md
@@ -266,6 +266,55 @@ Pour la cascade complète, déposez les poids dans `models/` (ou pointez
 `THUMALIEN_MODEL_DIR` vers leur emplacement) ; `cascade_full` passe alors à
 `true`.
 
+**Vérifier l'état des artefacts :**
+
+```bash
+python scripts/models_manifest.py status   # présents / manquants, cascade complète ou non
+python scripts/models_manifest.py verify   # empreintes SHA-256 (exécuté par la CI)
+```
+
+Les 29 artefacts versionnés sont empreintés dans `models/MANIFEST.json` : la CI
+échoue si l'un d'eux est altéré, supprimé ou ajouté sans suivi.
+
+---
+
+## Image Docker & déploiement
+
+L'API est publiée sur GitHub Container Registry à chaque push sur `main` :
+
+```bash
+docker pull ghcr.io/azelbanks/thumacheck:main
+docker run -p 8000:8000 ghcr.io/azelbanks/thumacheck:main \
+  uvicorn src.api.main:app --host 0.0.0.0 --port 8000
+```
+
+Tags disponibles : `main`, `sha-<court>` (chaque révision), et `vX.Y.Z` / `latest`
+sur les tags git.
+
+### Endpoints d'exploitation
+
+| Endpoint | Rôle |
+|---|---|
+| `/health` | **Vivacité** — 200 dès que le processus tourne |
+| `/ready` | **Disponibilité** — 200 seulement si une prédiction est possible, sinon **503** |
+| `/version` | Révision git, modèle chargé, état de la cascade |
+
+La distinction `/health` / `/ready` compte : un orchestrateur qui route sur
+`/health` envoie du trafic à une instance dont le modèle n'est pas encore
+chargé. Le `HEALTHCHECK` de l'image sonde `/ready`.
+
+`/version` permet de vérifier qu'un déploiement — ou un rollback — a bien pris
+effet :
+
+```json
+{"api_version": "1.0.0", "git_sha": "a1b2c3d", "model_suffix": "expert_v5",
+ "cascade_full": false, "build_time": "2026-08-02T10:00:00Z"}
+```
+
+Le workflow `release.yml` construit l'image, la publie, puis **démarre l'image
+publiée** et vérifie que `/version` annonce bien la révision attendue — une
+image cassée n'atteint pas un déploiement.
+
 ---
 
 ## Tests

--- a/models/MANIFEST.json
+++ b/models/MANIFEST.json
@@ -1,0 +1,128 @@
+{
+  "note": "Les poids listes dans optional_weights depassent la limite de 100 Mo de GitHub et ne sont pas versionnes. Leur absence place la cascade en mode degrade — voir la section « Modeles non versionnes » du README.",
+  "optional_weights": {
+    "camembert_best.pt": "CamemBERT — meilleur checkpoint d'entrainement",
+    "camembert_fr.pt": "CamemBERT FR fine-tune — etage FR de la cascade V9",
+    "camembert_fr_v2.pt": "CamemBERT FR v2 — variante textes ultra-courts",
+    "roberta_en.pt": "RoBERTa EN fine-tune — etage EN de la cascade V9",
+    "roberta_en_v2.pt": "RoBERTa EN v2 — +4.3 % F1 vs v1"
+  },
+  "versioned_artifacts": {
+    "config.json": {
+      "bytes": 738,
+      "sha256": "149dc5389d9443b535763ed9044a1379edab2233d90c52a6536cc4af68be4692"
+    },
+    "emotion_bilingual.pt": {
+      "bytes": 6421267,
+      "sha256": "89e15be53c2f62e6158381ccb19a44eb9eea1cb20513fd64c7c317b9d4b3a8a0"
+    },
+    "emotion_label_encoder_bilingual.pickle": {
+      "bytes": 467,
+      "sha256": "8af56e6e14f8493affef2a341748aa50cb65ff29f34de6ce5ccac784df58ef46"
+    },
+    "emotion_vocab_bilingual.pickle": {
+      "bytes": 341482,
+      "sha256": "65aac41ab877f0a0445be856162d769fc2f81978c709b68ece0475bfa40a47f5"
+    },
+    "hybrid_meta_learner.joblib": {
+      "bytes": 1119,
+      "sha256": "f49974ddc1283fcc993e1747896b99a19639b471602a70f5074f272b5463477c"
+    },
+    "logreg_baseline.pkl": {
+      "bytes": 40863,
+      "sha256": "f32d78f19db65a136550f9650092ea1004f433e887b09665bf323fe0b15ea827"
+    },
+    "metrics_expert.pkl": {
+      "bytes": 653,
+      "sha256": "332306bccc131af3f079802706f20d8554ac8bfe0f6ca9b7be8671953cd9c54d"
+    },
+    "metrics_expert_v2.pkl": {
+      "bytes": 657,
+      "sha256": "f662506e3d2ead60fc870f6d689e49b9322f103c86e961749200f8e0587b3ab9"
+    },
+    "metrics_expert_v3.pkl": {
+      "bytes": 657,
+      "sha256": "5312f31286a8c16257c71107df54b4a492627414830f78c870fc24fb27b81b1e"
+    },
+    "metrics_expert_v4.pkl": {
+      "bytes": 657,
+      "sha256": "cda5ae334567b7346457730cda9cb9a13e9d20ef9cfdcc328eff6c961e3588c0"
+    },
+    "metrics_expert_v5.pkl": {
+      "bytes": 659,
+      "sha256": "f9ef9b6faa4aad5849422a997212452fad9eb7b1adc802b68276e30aa9d91ee7"
+    },
+    "metrics_expert_v5_bluesky.pkl": {
+      "bytes": 503,
+      "sha256": "6f0dddaace7fc8ca608d7311bf65c48fe023fe7bec59922809768071be21da7e"
+    },
+    "model_expert.pkl": {
+      "bytes": 240959,
+      "sha256": "55c178d7a7e8011ced316025a5c63554e44f906a5fc9a3db00934f623e032c6a"
+    },
+    "model_expert_v2.pkl": {
+      "bytes": 240959,
+      "sha256": "96ca9862ad07c9e855816853e3aed4023f8f12a69d4fd228e129d37697ff7f26"
+    },
+    "model_expert_v3.pkl": {
+      "bytes": 240959,
+      "sha256": "609c4226a98c430a72e0bec31716d3c37a57a8c2e6ef786bec6e1c7737d92b1c"
+    },
+    "model_expert_v4.pkl": {
+      "bytes": 240991,
+      "sha256": "070593276d7d1f7651228780ed80bac8b364d6b64a5c26e296c591bdcf02d28e"
+    },
+    "model_expert_v5.pkl": {
+      "bytes": 240991,
+      "sha256": "c141f3c63fecd2518ee0751b25c384ac7c0f488bcf9cccfe341bd5c8289ba591"
+    },
+    "model_expert_v5_bluesky.pkl": {
+      "bytes": 160991,
+      "sha256": "f1e2d46241225c80779a3ac34082a91d5506432df405188e11ace41fe6b377a1"
+    },
+    "model_hybrid_v7.joblib": {
+      "bytes": 1258,
+      "sha256": "f15de3c7aba4c0ec470d72158558915331c9cb0d7954d75c42ca6a92f04aea4a"
+    },
+    "model_hybrid_v8.joblib": {
+      "bytes": 1397,
+      "sha256": "1802cd541d0285f0c6f295cff0a1d321a1a32701dcdf50ec1479e376e70e8b8e"
+    },
+    "model_style_v6.joblib": {
+      "bytes": 927043,
+      "sha256": "6e731d41dec43d7a6dbc5846a171aa87c2e751cc1a1e95fe45c5a3103a96787b"
+    },
+    "stage1_fact_opinion.joblib": {
+      "bytes": 104812,
+      "sha256": "df9f1b185830566ace137751ea42f1dff294b5b972f2eaadcc6ede0712e06c8a"
+    },
+    "tfidf_expert.pkl": {
+      "bytes": 1177799,
+      "sha256": "0bd4f76c94e40ca00a3292621b2f49eebe7f7e4322d20998386a3ec8052a555a"
+    },
+    "tfidf_expert_v2.pkl": {
+      "bytes": 1176078,
+      "sha256": "cf7b4c0ecae8ee8cc7efd9d1a5f47c6c0a439840724fac7c2c94a871acbd7b97"
+    },
+    "tfidf_expert_v3.pkl": {
+      "bytes": 1176078,
+      "sha256": "6874258ac59ca02d6b8752a99673379fcfb5d648f3cc22056b1d38671d53d379"
+    },
+    "tfidf_expert_v4.pkl": {
+      "bytes": 1171172,
+      "sha256": "1afcee5f758d0d22a7ba988a1b396631cffdef035923d95662c596c036eb11f1"
+    },
+    "tfidf_expert_v5.pkl": {
+      "bytes": 1171265,
+      "sha256": "1ee58f9acc7b5ad4052245e3119d5dd0ab276708e51717402c8baec3a90197b4"
+    },
+    "tfidf_expert_v5_bluesky.pkl": {
+      "bytes": 785321,
+      "sha256": "fcb45ce812735fa6d99979bac66baf6611930cb9ff344262cbb7744a840a8e53"
+    },
+    "tfidf_vectorizer.pkl": {
+      "bytes": 184261,
+      "sha256": "3f29487e50a5beecc71ac3cfdd3157d8851c4d3501671e4075b15168f404380b"
+    }
+  }
+}

--- a/scripts/batch_emotion_inference.py
+++ b/scripts/batch_emotion_inference.py
@@ -15,26 +15,28 @@ Prerequis : modeles dans models/ (emotion_bilingual.pt, vocab, label_encoder)
 """
 
 import os
+import pickle
 import sys
 import time
+
 import numpy as np
-import pickle
 
 # Ajouter src au path
-_proj = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, os.path.join(_proj, 'src'))
+_proj = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_proj, "src"))
 
-from pymongo import MongoClient, UpdateOne
 from urllib.parse import quote_plus
 
+from pymongo import MongoClient, UpdateOne
+
 BATCH_SIZE = 1000
-MODEL_DIR = os.path.join(_proj, 'models')
+MODEL_DIR = os.path.join(_proj, "models")
 
 
 def connect_db():
-    mongo_host = os.getenv('MONGO_HOST', 'mongodb')
-    mongo_user = os.getenv('MONGO_USER', '')
-    mongo_pwd = os.getenv('MONGO_PASSWORD', '')
+    mongo_host = os.getenv("MONGO_HOST", "mongodb")
+    mongo_user = os.getenv("MONGO_USER", "")
+    mongo_pwd = os.getenv("MONGO_PASSWORD", "")
 
     if mongo_user and mongo_pwd:
         uri = f"mongodb://{quote_plus(mongo_user)}:{quote_plus(mongo_pwd)}@{mongo_host}:27017/?authSource=admin"
@@ -42,38 +44,39 @@ def connect_db():
         uri = f"mongodb://{mongo_host}:27017/"
 
     client = MongoClient(uri, serverSelectionTimeoutMS=10000)
-    client.admin.command('ping')
-    return client['thumalien_db']['raw_posts']
+    client.admin.command("ping")
+    return client["thumalien_db"]["raw_posts"]
 
 
 def load_emotion_model():
     """Charge le modele MLP emotions bilingue."""
     import torch
 
-    vocab_path = os.path.join(MODEL_DIR, 'emotion_vocab_bilingual.pickle')
-    le_path = os.path.join(MODEL_DIR, 'emotion_label_encoder_bilingual.pickle')
-    model_path = os.path.join(MODEL_DIR, 'emotion_bilingual.pt')
+    vocab_path = os.path.join(MODEL_DIR, "emotion_vocab_bilingual.pickle")
+    le_path = os.path.join(MODEL_DIR, "emotion_label_encoder_bilingual.pickle")
+    model_path = os.path.join(MODEL_DIR, "emotion_bilingual.pt")
 
-    with open(vocab_path, 'rb') as f:
+    with open(vocab_path, "rb") as f:
         vocab = pickle.load(f)
-    with open(le_path, 'rb') as f:
+    with open(le_path, "rb") as f:
         label_encoder = pickle.load(f)
 
-    checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)
+    checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
 
     # Le checkpoint peut etre un dict avec 'model_state_dict' ou directement un state_dict
-    if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint:
-        state_dict = checkpoint['model_state_dict']
-        max_len = checkpoint.get('max_len', 100)
+    if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+        state_dict = checkpoint["model_state_dict"]
+        max_len = checkpoint.get("max_len", 100)
     else:
         state_dict = checkpoint
         max_len = 100
 
-    vocab_size = state_dict['embedding.weight'].shape[0]
-    embed_dim = state_dict['embedding.weight'].shape[1]
-    n_classes = state_dict['fc3.weight'].shape[0]
+    vocab_size = state_dict["embedding.weight"].shape[0]
+    embed_dim = state_dict["embedding.weight"].shape[1]
+    n_classes = state_dict["fc3.weight"].shape[0]
 
     from pipeline.expert_detector import _EmotionMLP as EmotionMLP
+
     model = EmotionMLP(vocab_size, embed_dim, n_classes)
     model.load_state_dict(state_dict)
     model.eval()
@@ -85,12 +88,12 @@ def predict_emotions_batch(texts, model, vocab, label_encoder, max_len):
     """Predit les emotions pour un batch de textes."""
     import torch
 
-    pad_idx = vocab.get('<PAD>', 0)
+    pad_idx = vocab.get("<PAD>", 0)
 
     sequences = []
     for text in texts:
         tokens = str(text).lower().split()
-        ids = [vocab.get(t, vocab.get('<UNK>', 1)) for t in tokens[:max_len]]
+        ids = [vocab.get(t, vocab.get("<UNK>", 1)) for t in tokens[:max_len]]
         if len(ids) < max_len:
             ids += [pad_idx] * (max_len - len(ids))
         sequences.append(ids)
@@ -125,11 +128,11 @@ def main():
 
     # 3. Compter les posts a traiter
     query = {
-        'text': {'$exists': True, '$ne': ''},
-        '$or': [
-            {'ai_emotion': {'$exists': False}},
-            {'ai_emotion': None},
-        ]
+        "text": {"$exists": True, "$ne": ""},
+        "$or": [
+            {"ai_emotion": {"$exists": False}},
+            {"ai_emotion": None},
+        ],
     }
     total = collection.count_documents(query)
     print(f"\n[3/3] Posts sans emotion : {total}")
@@ -144,29 +147,30 @@ def main():
 
     while processed < total:
         batch_num += 1
-        cursor = collection.find(
-            query,
-            {'_id': 1, 'text': 1}
-        ).limit(BATCH_SIZE)
+        cursor = collection.find(query, {"_id": 1, "text": 1}).limit(BATCH_SIZE)
 
         docs = list(cursor)
         if not docs:
             break
 
-        texts = [d.get('text', '') for d in docs]
-        ids = [d['_id'] for d in docs]
+        texts = [d.get("text", "") for d in docs]
+        ids = [d["_id"] for d in docs]
 
         labels, probs = predict_emotions_batch(texts, model, vocab, label_encoder, max_len)
 
         ops = []
         for i, (_id, label) in enumerate(zip(ids, labels)):
-            ops.append(UpdateOne(
-                {'_id': _id},
-                {'$set': {
-                    'ai_emotion': str(label),
-                    'ai_emotion_model': 'emotion_bilingual_v1',
-                }}
-            ))
+            ops.append(
+                UpdateOne(
+                    {"_id": _id},
+                    {
+                        "$set": {
+                            "ai_emotion": str(label),
+                            "ai_emotion_model": "emotion_bilingual_v1",
+                        }
+                    },
+                )
+            )
 
         if ops:
             collection.bulk_write(ops)
@@ -175,13 +179,15 @@ def main():
         elapsed = time.time() - t0
         rate = processed / elapsed if elapsed > 0 else 0
         remaining = (total - processed) / rate if rate > 0 else 0
-        print(f"  Batch {batch_num}: {processed}/{total} ({processed/total*100:.1f}%) "
-              f"- {rate:.0f} posts/s - ETA {remaining/60:.1f}min")
+        print(
+            f"  Batch {batch_num}: {processed}/{total} ({processed / total * 100:.1f}%) "
+            f"- {rate:.0f} posts/s - ETA {remaining / 60:.1f}min"
+        )
 
     elapsed = time.time() - t0
     print(f"\nTermine : {processed} posts traites en {elapsed:.0f}s")
     print("=" * 60)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/batch_v9_rescoring.py
+++ b/scripts/batch_v9_rescoring.py
@@ -13,43 +13,44 @@ Usage :
 import os
 import sys
 import time
+
 import joblib
-import numpy as np
 
 # Path setup
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, os.path.join(PROJECT_ROOT, 'src'))
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "src"))
 
-from pymongo import MongoClient, UpdateOne
 from dotenv import load_dotenv
+from pymongo import MongoClient, UpdateOne
 
-load_dotenv(os.path.join(PROJECT_ROOT, '.env'))
+load_dotenv(os.path.join(PROJECT_ROOT, ".env"))
 
 
 def connect_db():
-    host = os.getenv('MONGO_HOST', 'localhost')
-    user = os.getenv('MONGO_USER', '')
-    password = os.getenv('MONGO_PASSWORD', '')
+    host = os.getenv("MONGO_HOST", "localhost")
+    user = os.getenv("MONGO_USER", "")
+    password = os.getenv("MONGO_PASSWORD", "")
 
     if user and password:
         from urllib.parse import quote_plus
+
         uri = f"mongodb://{quote_plus(user)}:{quote_plus(password)}@{host}:27017/?authSource=admin"
     else:
         uri = f"mongodb://{host}:27017/"
 
     client = MongoClient(uri, serverSelectionTimeoutMS=5000)
     client.server_info()
-    return client['thumalien_db']['raw_posts']
+    return client["thumalien_db"]["raw_posts"]
 
 
 def load_stage1():
-    path = os.path.join(PROJECT_ROOT, 'models', 'stage1_fact_opinion.joblib')
+    path = os.path.join(PROJECT_ROOT, "models", "stage1_fact_opinion.joblib")
     if not os.path.exists(path):
         print(f"Stage 1 model not found: {path}")
         sys.exit(1)
     data = joblib.load(path)
-    pipeline = data['pipeline']
-    threshold = data.get('threshold', 0.40)
+    pipeline = data["pipeline"]
+    threshold = data.get("threshold", 0.40)
     print(f"Stage 1 loaded (threshold={threshold})")
     return pipeline, threshold
 
@@ -62,8 +63,8 @@ def main():
 
     # Count posts to process (those without ai_post_type)
     query = {
-        'text': {'$exists': True, '$ne': ''},
-        'ai_post_type': {'$exists': False},
+        "text": {"$exists": True, "$ne": ""},
+        "ai_post_type": {"$exists": False},
     }
     total = collection.count_documents(query)
     print(f"Posts a traiter : {total}")
@@ -74,17 +75,19 @@ def main():
 
     batch_size = 1000
     processed = 0
-    stats = {'factuel': 0, 'opinion': 0, 'reclassed': 0}
+    stats = {"factuel": 0, "opinion": 0, "reclassed": 0}
     start = time.time()
 
     while processed < total:
-        docs = list(collection.find(query, {'_id': 1, 'text': 1, 'prediction_label': 1}).limit(batch_size))
+        docs = list(
+            collection.find(query, {"_id": 1, "text": 1, "prediction_label": 1}).limit(batch_size)
+        )
         if not docs:
             break
 
-        texts = [d.get('text', '') for d in docs]
-        ids = [d['_id'] for d in docs]
-        original_labels = [d.get('prediction_label', 0) for d in docs]
+        texts = [d.get("text", "") for d in docs]
+        ids = [d["_id"] for d in docs]
+        original_labels = [d.get("prediction_label", 0) for d in docs]
 
         # Stage 1 prediction
         try:
@@ -99,24 +102,28 @@ def main():
         ops = []
         for i, _id in enumerate(ids):
             pf = float(p_factuel[i])
-            post_type = 'factuel' if pf >= s1_threshold else 'opinion'
+            post_type = "factuel" if pf >= s1_threshold else "opinion"
 
             # V9 logic: if opinion AND was suspect, reclassify as fiable
             v9_label = original_labels[i]
-            if post_type == 'opinion' and v9_label == 1:
+            if post_type == "opinion" and v9_label == 1:
                 v9_label = 0  # Opinion => not fake news
-                stats['reclassed'] += 1
+                stats["reclassed"] += 1
 
             stats[post_type] += 1
 
-            ops.append(UpdateOne(
-                {'_id': _id},
-                {'$set': {
-                    'ai_post_type': post_type,
-                    'ai_post_type_proba': round(pf, 4),
-                    'ai_v9_label': int(v9_label),
-                }}
-            ))
+            ops.append(
+                UpdateOne(
+                    {"_id": _id},
+                    {
+                        "$set": {
+                            "ai_post_type": post_type,
+                            "ai_post_type_proba": round(pf, 4),
+                            "ai_v9_label": int(v9_label),
+                        }
+                    },
+                )
+            )
 
         if ops:
             collection.bulk_write(ops)
@@ -134,12 +141,14 @@ def main():
 
     # Final stats
     total_posts = collection.count_documents({})
-    v5_suspects = collection.count_documents({'prediction_label': 1})
-    v9_suspects = collection.count_documents({'ai_v9_label': 1})
-    print(f"\n  V5 suspects : {v5_suspects}/{total_posts} ({v5_suspects/total_posts*100:.1f}%)")
-    print(f"  V9 suspects : {v9_suspects}/{total_posts} ({v9_suspects/total_posts*100:.1f}%)")
-    print(f"  Reduction FP : {v5_suspects - v9_suspects} posts ({(v5_suspects - v9_suspects)/v5_suspects*100:.1f}%)")
+    v5_suspects = collection.count_documents({"prediction_label": 1})
+    v9_suspects = collection.count_documents({"ai_v9_label": 1})
+    print(f"\n  V5 suspects : {v5_suspects}/{total_posts} ({v5_suspects / total_posts * 100:.1f}%)")
+    print(f"  V9 suspects : {v9_suspects}/{total_posts} ({v9_suspects / total_posts * 100:.1f}%)")
+    print(
+        f"  Reduction FP : {v5_suspects - v9_suspects} posts ({(v5_suspects - v9_suspects) / v5_suspects * 100:.1f}%)"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/bootstrap_fp_gold.py
+++ b/scripts/bootstrap_fp_gold.py
@@ -55,9 +55,9 @@ def bootstrap_fp_reduction():
 def bootstrap_fisher_pvalue():
     """Bootstrap p-value for Fisher's exact test on FP counts."""
     from scipy.stats import fisher_exact
-    table = [[FP_V9, N_FIABLE - FP_V9],
-             [FP_V5, N_FIABLE - FP_V5]]
-    _, p = fisher_exact(table, alternative='less')
+
+    table = [[FP_V9, N_FIABLE - FP_V9], [FP_V5, N_FIABLE - FP_V5]]
+    _, p = fisher_exact(table, alternative="less")
     return p
 
 
@@ -72,7 +72,7 @@ def main():
 
     median, ci_low, ci_high, reductions = bootstrap_fp_reduction()
 
-    print(f"\nResultats :")
+    print("\nResultats :")
     print(f"  Median reduction  = {median:.1%}")
     print(f"  IC 95%            = [{ci_low:.1%}, {ci_high:.1%}]")
     print(f"  IC ne contient pas 0 : {'OUI' if ci_high < 0 else 'NON'}")
@@ -83,8 +83,8 @@ def main():
     except ImportError:
         print("  (scipy non disponible pour Fisher exact)")
 
-    print(f"\nConclusion : la reduction des FP est statistiquement significative")
-    print(f"(IC 95% entierement negatif = V9 produit moins de FP que V5)")
+    print("\nConclusion : la reduction des FP est statistiquement significative")
+    print("(IC 95% entierement negatif = V9 produit moins de FP que V5)")
     print("=" * 60)
 
 

--- a/scripts/capture_dashboard.py
+++ b/scripts/capture_dashboard.py
@@ -12,7 +12,6 @@ Usage :
 Les captures sont sauvegardees dans docs/figures/screenshots/
 """
 
-import sys
 import time
 from pathlib import Path
 
@@ -73,6 +72,7 @@ def main():
 
     # Check if dashboard is running
     import urllib.request
+
     try:
         urllib.request.urlopen("http://localhost:8501/", timeout=3)
     except Exception:
@@ -85,7 +85,9 @@ def main():
             placeholder = OUTPUT_DIR / f"{name}.png"
             if not placeholder.exists():
                 # Create a minimal placeholder text file
-                placeholder.write_text(f"[Placeholder — lancer le dashboard puis re-executer capture_dashboard.py]")
+                placeholder.write_text(
+                    "[Placeholder — lancer le dashboard puis re-executer capture_dashboard.py]"
+                )
                 print(f"  [PLACEHOLDER] {name}.png")
         return
 

--- a/scripts/create_gold_sheet.py
+++ b/scripts/create_gold_sheet.py
@@ -17,17 +17,15 @@ Auteur: Azelie Bernard - Thumalien Team
 """
 
 import argparse
-import sys
 import os
+import sys
 
 import pandas as pd
 from openpyxl import Workbook
-from openpyxl.styles import (
-    Font, PatternFill, Alignment, Border, Side, Protection
-)
+from openpyxl.formatting.rule import CellIsRule
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.datavalidation import DataValidation
-from openpyxl.formatting.rule import CellIsRule
 
 
 def create_annotation_sheet(ws, df, annotateur_num):
@@ -38,12 +36,16 @@ def create_annotation_sheet(ws, df, annotateur_num):
     HEADER_FILL = PatternFill(start_color="2C3E50", end_color="2C3E50", fill_type="solid")
     HEADER_FONT = Font(name="Arial", size=11, bold=True, color="FFFFFF")
     TEXT_FONT = Font(name="Arial", size=10)
-    ANNOT_FILL = PatternFill(start_color="FFF9C4", end_color="FFF9C4", fill_type="solid")  # jaune clair
+    ANNOT_FILL = PatternFill(
+        start_color="FFF9C4", end_color="FFF9C4", fill_type="solid"
+    )  # jaune clair
     GREEN_FILL = PatternFill(start_color="C8E6C9", end_color="C8E6C9", fill_type="solid")
     RED_FILL = PatternFill(start_color="FFCDD2", end_color="FFCDD2", fill_type="solid")
     BORDER = Border(
-        left=Side(style="thin"), right=Side(style="thin"),
-        top=Side(style="thin"), bottom=Side(style="thin")
+        left=Side(style="thin"),
+        right=Side(style="thin"),
+        top=Side(style="thin"),
+        bottom=Side(style="thin"),
     )
 
     # --- En-tetes ---
@@ -110,7 +112,7 @@ def create_annotation_sheet(ws, df, annotateur_num):
         error="Choisir: fiable ou suspect",
         showInputMessage=True,
         promptTitle="Label",
-        prompt="fiable = post credible/normal\nsuspect = desinformation/manipulation"
+        prompt="fiable = post credible/normal\nsuspect = desinformation/manipulation",
     )
     dv_label.add(f"F2:F{n_rows}")
     ws.add_data_validation(dv_label)
@@ -125,19 +127,17 @@ def create_annotation_sheet(ws, df, annotateur_num):
         error="Choisir: 1 (pas sur), 2 (assez sur), 3 (certain)",
         showInputMessage=True,
         promptTitle="Confiance",
-        prompt="1 = pas sur\n2 = assez sur\n3 = certain"
+        prompt="1 = pas sur\n2 = assez sur\n3 = certain",
     )
     dv_conf.add(f"G2:G{n_rows}")
     ws.add_data_validation(dv_conf)
 
     # --- Mise en forme conditionnelle ---
     ws.conditional_formatting.add(
-        f"F2:F{n_rows}",
-        CellIsRule(operator="equal", formula=['"fiable"'], fill=GREEN_FILL)
+        f"F2:F{n_rows}", CellIsRule(operator="equal", formula=['"fiable"'], fill=GREEN_FILL)
     )
     ws.conditional_formatting.add(
-        f"F2:F{n_rows}",
-        CellIsRule(operator="equal", formula=['"suspect"'], fill=RED_FILL)
+        f"F2:F{n_rows}", CellIsRule(operator="equal", formula=['"suspect"'], fill=RED_FILL)
     )
 
     # --- Figer la premiere ligne + colonne texte ---
@@ -164,25 +164,39 @@ def create_guidelines_sheet(wb):
     row = 2
     ws.cell(row=row, column=2, value="GOLD TEST SET - Consignes d'annotation").font = TITLE_FONT
     row += 1
-    ws.cell(row=row, column=2, value="Projet Thumalien - Detection de desinformation sur Bluesky").font = TEXT_FONT
+    ws.cell(
+        row=row, column=2, value="Projet Thumalien - Detection de desinformation sur Bluesky"
+    ).font = TEXT_FONT
     row += 2
 
     ws.cell(row=row, column=2, value="OBJECTIF").font = SECTION_FONT
     row += 1
-    ws.cell(row=row, column=2,
-            value="Annoter chaque post comme 'fiable' ou 'suspect' SANS connaitre la prediction de l'IA.").font = TEXT_FONT
+    ws.cell(
+        row=row,
+        column=2,
+        value="Annoter chaque post comme 'fiable' ou 'suspect' SANS connaitre la prediction de l'IA.",
+    ).font = TEXT_FONT
     row += 1
-    ws.cell(row=row, column=2,
-            value="Ce gold set servira a evaluer la qualite reelle des modeles sur des donnees non synthetiques.").font = TEXT_FONT
+    ws.cell(
+        row=row,
+        column=2,
+        value="Ce gold set servira a evaluer la qualite reelle des modeles sur des donnees non synthetiques.",
+    ).font = TEXT_FONT
     row += 2
 
     ws.cell(row=row, column=2, value="DEFINITIONS").font = SECTION_FONT
     row += 1
-    ws.cell(row=row, column=2,
-            value="SUSPECT = desinformation, theorie du complot, manipulation, affirmation fausse non sourcee").font = RED
+    ws.cell(
+        row=row,
+        column=2,
+        value="SUSPECT = desinformation, theorie du complot, manipulation, affirmation fausse non sourcee",
+    ).font = RED
     row += 1
-    ws.cell(row=row, column=2,
-            value="FIABLE = post factuel, source, opinion/expression normale, humour/satire identifiable").font = GREEN
+    ws.cell(
+        row=row,
+        column=2,
+        value="FIABLE = post factuel, source, opinion/expression normale, humour/satire identifiable",
+    ).font = GREEN
     row += 2
 
     ws.cell(row=row, column=2, value="REGLES DE DECISION").font = SECTION_FONT
@@ -206,9 +220,15 @@ def create_guidelines_sheet(wb):
     row += 1
     ws.cell(row=row, column=2, value="1 = pas sur (je devine, le post est ambigu)").font = TEXT_FONT
     row += 1
-    ws.cell(row=row, column=2, value="2 = assez sur (je pense avoir raison mais c'est discutable)").font = TEXT_FONT
+    ws.cell(
+        row=row, column=2, value="2 = assez sur (je pense avoir raison mais c'est discutable)"
+    ).font = TEXT_FONT
     row += 1
-    ws.cell(row=row, column=2, value="3 = certain (aucun doute, le post est clairement fiable ou suspect)").font = TEXT_FONT
+    ws.cell(
+        row=row,
+        column=2,
+        value="3 = certain (aucun doute, le post est clairement fiable ou suspect)",
+    ).font = TEXT_FONT
     row += 2
 
     ws.cell(row=row, column=2, value="PROCEDURE").font = SECTION_FONT
@@ -236,15 +256,25 @@ def create_resolution_sheet(wb, df):
     HEADER_FONT = Font(name="Arial", size=11, bold=True, color="FFFFFF")
     TEXT_FONT = Font(name="Arial", size=10)
     BORDER = Border(
-        left=Side(style="thin"), right=Side(style="thin"),
-        top=Side(style="thin"), bottom=Side(style="thin")
+        left=Side(style="thin"),
+        right=Side(style="thin"),
+        top=Side(style="thin"),
+        bottom=Side(style="thin"),
     )
 
     headers = [
-        ("ID", 6), ("Texte", 80), ("Langue", 8),
-        ("Label A1", 12), ("Conf. A1", 10), ("Justif. A1", 25),
-        ("Label A2", 12), ("Conf. A2", 10), ("Justif. A2", 25),
-        ("Desaccord?", 12), ("Label final", 15), ("Commentaire", 35),
+        ("ID", 6),
+        ("Texte", 80),
+        ("Langue", 8),
+        ("Label A1", 12),
+        ("Conf. A1", 10),
+        ("Justif. A1", 25),
+        ("Label A2", 12),
+        ("Conf. A2", 10),
+        ("Justif. A2", 25),
+        ("Desaccord?", 12),
+        ("Label final", 15),
+        ("Commentaire", 35),
     ]
 
     for col_idx, (name, width) in enumerate(headers, 1):
@@ -276,7 +306,9 @@ def create_resolution_sheet(wb, df):
 
     # Formule desaccord (=SI(D2<>G2, "OUI", ""))
     for row_idx in range(2, n_rows + 1):
-        ws.cell(row=row_idx, column=10).value = f'=IF(AND(D{row_idx}<>"",G{row_idx}<>""),IF(D{row_idx}<>G{row_idx},"OUI",""),"")'
+        ws.cell(
+            row=row_idx, column=10
+        ).value = f'=IF(AND(D{row_idx}<>"",G{row_idx}<>""),IF(D{row_idx}<>G{row_idx},"OUI",""),"")'
 
     ws.freeze_panes = "C2"
     return ws
@@ -284,13 +316,10 @@ def create_resolution_sheet(wb, df):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--from-csv", type=str, default=None,
-                        help="Charger depuis un CSV existant")
-    parser.add_argument("--from-mongo", action="store_true",
-                        help="Extraire depuis MongoDB")
+    parser.add_argument("--from-csv", type=str, default=None, help="Charger depuis un CSV existant")
+    parser.add_argument("--from-mongo", action="store_true", help="Extraire depuis MongoDB")
     parser.add_argument("--n_posts", type=int, default=200)
-    parser.add_argument("--output", type=str,
-                        default="data/gold_test_set_annotation.xlsx")
+    parser.add_argument("--output", type=str, default="data/gold_test_set_annotation.xlsx")
     parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
 
@@ -301,21 +330,25 @@ def main():
     elif args.from_mongo:
         print("Extraction depuis MongoDB...")
         import random
+
         random.seed(args.seed)
         sys.path.insert(0, os.path.dirname(__file__))
-        from extract_gold_test_set import get_mongo_collection, extract_stratified_sample
+        from extract_gold_test_set import extract_stratified_sample, get_mongo_collection
+
         collection = get_mongo_collection()
         posts = extract_stratified_sample(collection, args.n_posts)
         # Convertir en DataFrame
         rows = []
         for i, p in enumerate(posts, 1):
-            rows.append({
-                "id": i,
-                "text": p.get("text", ""),
-                "langue": p.get("ai_language", ""),
-                "nb_mots": p.get("text_word_count", 0),
-                "strate": p.get("strate", ""),
-            })
+            rows.append(
+                {
+                    "id": i,
+                    "text": p.get("text", ""),
+                    "langue": p.get("ai_language", ""),
+                    "nb_mots": p.get("text_word_count", 0),
+                    "strate": p.get("strate", ""),
+                }
+            )
         df = pd.DataFrame(rows)
         # Sauvegarder aussi en CSV
         csv_path = args.output.replace(".xlsx", ".csv")
@@ -354,14 +387,14 @@ def main():
     # --- Sauvegarder ---
     wb.save(args.output)
     print(f"\nFichier cree: {args.output}")
-    print(f"\nOnglets:")
-    print(f"  1. Guidelines      - Consignes d'annotation (lire en premier)")
-    print(f"  2. Annotateur_1    - Onglet vert (toi)")
-    print(f"  3. Annotateur_2    - Onglet bleu (2e annotateur)")
-    print(f"  4. Resolution      - Pour resoudre les desaccords apres")
-    print(f"\nPour importer dans Google Sheets:")
+    print("\nOnglets:")
+    print("  1. Guidelines      - Consignes d'annotation (lire en premier)")
+    print("  2. Annotateur_1    - Onglet vert (toi)")
+    print("  3. Annotateur_2    - Onglet bleu (2e annotateur)")
+    print("  4. Resolution      - Pour resoudre les desaccords apres")
+    print("\nPour importer dans Google Sheets:")
     print(f"  Google Drive → Nouveau → Importer → {args.output}")
-    print(f"  Les menus deroulants seront preserves.")
+    print("  Les menus deroulants seront preserves.")
 
 
 if __name__ == "__main__":

--- a/scripts/extract_gold_test_set.py
+++ b/scripts/extract_gold_test_set.py
@@ -13,16 +13,14 @@ Usage:
 Auteur: Azelie Bernard - Thumalien Team
 """
 
-import os
-import sys
 import argparse
+import os
 import random
-from datetime import datetime
+from urllib.parse import quote_plus
 
 import pandas as pd
-from pymongo import MongoClient
-from urllib.parse import quote_plus
 from dotenv import load_dotenv
+from pymongo import MongoClient
 
 load_dotenv()
 
@@ -67,33 +65,65 @@ def extract_stratified_sample(collection, n_posts=500):
             n_court = int(n_strate * 0.3)
             n_long = n_strate - n_ultra - n_court
 
-            strata.append({
-                "lang": lang, "pred": pred,
-                "length": "ultra", "n": n_ultra,
-                "query": {"ai_language": lang, "prediction_label": pred,
-                          "text_word_count": {"$lt": 15}, "ai_processed": True}
-            })
-            strata.append({
-                "lang": lang, "pred": pred,
-                "length": "court", "n": n_court,
-                "query": {"ai_language": lang, "prediction_label": pred,
-                          "text_word_count": {"$gte": 15, "$lt": 30}, "ai_processed": True}
-            })
-            strata.append({
-                "lang": lang, "pred": pred,
-                "length": "long", "n": n_long,
-                "query": {"ai_language": lang, "prediction_label": pred,
-                          "text_word_count": {"$gte": 30}, "ai_processed": True}
-            })
+            strata.append(
+                {
+                    "lang": lang,
+                    "pred": pred,
+                    "length": "ultra",
+                    "n": n_ultra,
+                    "query": {
+                        "ai_language": lang,
+                        "prediction_label": pred,
+                        "text_word_count": {"$lt": 15},
+                        "ai_processed": True,
+                    },
+                }
+            )
+            strata.append(
+                {
+                    "lang": lang,
+                    "pred": pred,
+                    "length": "court",
+                    "n": n_court,
+                    "query": {
+                        "ai_language": lang,
+                        "prediction_label": pred,
+                        "text_word_count": {"$gte": 15, "$lt": 30},
+                        "ai_processed": True,
+                    },
+                }
+            )
+            strata.append(
+                {
+                    "lang": lang,
+                    "pred": pred,
+                    "length": "long",
+                    "n": n_long,
+                    "query": {
+                        "ai_language": lang,
+                        "prediction_label": pred,
+                        "text_word_count": {"$gte": 30},
+                        "ai_processed": True,
+                    },
+                }
+            )
 
     all_posts = []
     for s in strata:
         cursor = collection.find(
             s["query"],
-            {"_id": 0, "uri": 1, "text": 1, "ai_language": 1,
-             "prediction_label": 1, "ai_score_credibility": 1,
-             "text_word_count": 1, "created_at": 1, "author_handle": 1,
-             "search_term": 1}
+            {
+                "_id": 0,
+                "uri": 1,
+                "text": 1,
+                "ai_language": 1,
+                "prediction_label": 1,
+                "ai_score_credibility": 1,
+                "text_word_count": 1,
+                "created_at": 1,
+                "author_handle": 1,
+                "search_term": 1,
+            },
         )
         posts = list(cursor)
 
@@ -101,21 +131,30 @@ def extract_stratified_sample(collection, n_posts=500):
             posts = random.sample(posts, s["n"])
 
         for p in posts:
-            p["strate"] = f"{s['lang']}_{['fiable','suspect'][s['pred']]}_{s['length']}"
+            p["strate"] = f"{s['lang']}_{['fiable', 'suspect'][s['pred']]}_{s['length']}"
 
         all_posts.extend(posts)
-        print(f"  Strate {s['lang']}/{['fiable','suspect'][s['pred']]}/{s['length']}: "
-              f"{len(posts)}/{s['n']} posts extraits")
+        print(
+            f"  Strate {s['lang']}/{['fiable', 'suspect'][s['pred']]}/{s['length']}: "
+            f"{len(posts)}/{s['n']} posts extraits"
+        )
 
     # Ajouter des cas frontiere (score entre 0.3 et 0.7)
     n_frontiere = max(20, n_posts // 10)
     cursor_frontiere = collection.find(
-        {"ai_processed": True,
-         "ai_score_credibility": {"$gte": 0.3, "$lte": 0.7}},
-        {"_id": 0, "uri": 1, "text": 1, "ai_language": 1,
-         "prediction_label": 1, "ai_score_credibility": 1,
-         "text_word_count": 1, "created_at": 1, "author_handle": 1,
-         "search_term": 1}
+        {"ai_processed": True, "ai_score_credibility": {"$gte": 0.3, "$lte": 0.7}},
+        {
+            "_id": 0,
+            "uri": 1,
+            "text": 1,
+            "ai_language": 1,
+            "prediction_label": 1,
+            "ai_score_credibility": 1,
+            "text_word_count": 1,
+            "created_at": 1,
+            "author_handle": 1,
+            "search_term": 1,
+        },
     )
     frontiere_posts = list(cursor_frontiere)
     if len(frontiere_posts) > n_frontiere:
@@ -144,28 +183,30 @@ def create_annotation_csv(posts, output_path):
     """
     rows = []
     for i, p in enumerate(posts, 1):
-        rows.append({
-            "id": i,
-            "uri": p.get("uri", ""),
-            "text": p.get("text", ""),
-            "langue": p.get("ai_language", ""),
-            "nb_mots": p.get("text_word_count", 0),
-            "strate": p.get("strate", ""),
-            "search_term": p.get("search_term", ""),
-            # Colonnes d'annotation (a remplir manuellement)
-            "annotateur_1": "",           # fiable / suspect
-            "confiance_1": "",            # 1=pas sur, 2=assez sur, 3=certain
-            "justification_1": "",        # texte libre court
-            "annotateur_2": "",           # fiable / suspect
-            "confiance_2": "",            # 1=pas sur, 2=assez sur, 3=certain
-            "justification_2": "",        # texte libre court
-            # Colonnes de resolution (apres annotation)
-            "label_final": "",            # fiable / suspect (apres arbitrage)
-            "desaccord": "",              # oui / non
-            # Prediction IA (MASQUE pendant l'annotation, visible apres)
-            "ia_prediction": p.get("prediction_label", ""),
-            "ia_score": round(p.get("ai_score_credibility", 0), 4),
-        })
+        rows.append(
+            {
+                "id": i,
+                "uri": p.get("uri", ""),
+                "text": p.get("text", ""),
+                "langue": p.get("ai_language", ""),
+                "nb_mots": p.get("text_word_count", 0),
+                "strate": p.get("strate", ""),
+                "search_term": p.get("search_term", ""),
+                # Colonnes d'annotation (a remplir manuellement)
+                "annotateur_1": "",  # fiable / suspect
+                "confiance_1": "",  # 1=pas sur, 2=assez sur, 3=certain
+                "justification_1": "",  # texte libre court
+                "annotateur_2": "",  # fiable / suspect
+                "confiance_2": "",  # 1=pas sur, 2=assez sur, 3=certain
+                "justification_2": "",  # texte libre court
+                # Colonnes de resolution (apres annotation)
+                "label_final": "",  # fiable / suspect (apres arbitrage)
+                "desaccord": "",  # oui / non
+                # Prediction IA (MASQUE pendant l'annotation, visible apres)
+                "ia_prediction": p.get("prediction_label", ""),
+                "ia_score": round(p.get("ai_score_credibility", 0), 4),
+            }
+        )
 
     df = pd.DataFrame(rows)
     df.to_csv(output_path, index=False, encoding="utf-8")
@@ -175,7 +216,7 @@ def create_annotation_csv(posts, output_path):
     df_blind = df.drop(columns=["ia_prediction", "ia_score"])
     df_blind.to_csv(blind_path, index=False, encoding="utf-8")
 
-    print(f"\nFichiers crees :")
+    print("\nFichiers crees :")
     print(f"  {output_path} (complet, avec predictions IA)")
     print(f"  {blind_path} (aveugle, pour les annotateurs)")
 
@@ -186,11 +227,11 @@ def print_stats(df):
     """Affiche les statistiques de l'echantillon."""
     print("\n--- Statistiques de l'echantillon ---")
     print(f"Total: {len(df)} posts")
-    print(f"\nPar langue:")
+    print("\nPar langue:")
     print(df["langue"].value_counts().to_string())
-    print(f"\nPar strate:")
+    print("\nPar strate:")
     print(df["strate"].value_counts().to_string())
-    print(f"\nNombre de mots - stats:")
+    print("\nNombre de mots - stats:")
     print(f"  Moyenne: {df['nb_mots'].mean():.1f}")
     print(f"  Mediane: {df['nb_mots'].median():.0f}")
     print(f"  Min/Max: {df['nb_mots'].min()}/{df['nb_mots'].max()}")
@@ -198,13 +239,13 @@ def print_stats(df):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Extraction gold test set")
-    parser.add_argument("--n_posts", type=int, default=200,
-                        help="Nombre total de posts (default: 200)")
-    parser.add_argument("--output", type=str,
-                        default="data/gold_test_set.csv",
-                        help="Chemin de sortie")
-    parser.add_argument("--seed", type=int, default=42,
-                        help="Seed aleatoire")
+    parser.add_argument(
+        "--n_posts", type=int, default=200, help="Nombre total de posts (default: 200)"
+    )
+    parser.add_argument(
+        "--output", type=str, default="data/gold_test_set.csv", help="Chemin de sortie"
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Seed aleatoire")
     args = parser.parse_args()
 
     random.seed(args.seed)

--- a/scripts/models_manifest.py
+++ b/scripts/models_manifest.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Manifeste verifiable des artefacts de modeles.
+
+Pourquoi
+--------
+Les poids CamemBERT et RoBERTa depassent la limite de 100 Mo de GitHub et ne
+sont pas versionnes : un clone frais tourne en cascade degradee. Rien ne
+permettait jusqu'ici de savoir *quels* artefacts sont presents, *lesquels*
+manquent, ni de verifier que ceux presents n'ont pas ete alteres.
+
+Ce script produit et verifie `models/MANIFEST.json` : empreinte SHA-256 et
+taille de chaque artefact versionne, plus la liste explicite des poids
+optionnels attendus.
+
+Usage
+-----
+    python scripts/models_manifest.py generate   # (re)genere le manifeste
+    python scripts/models_manifest.py verify     # verifie l'existant (exit 1 si ecart)
+    python scripts/models_manifest.py status     # etat lisible de la cascade
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODELS_DIR = os.path.join(REPO_ROOT, "models")
+MANIFEST_PATH = os.path.join(MODELS_DIR, "MANIFEST.json")
+
+# Poids trop volumineux pour GitHub (> 100 Mo), volontairement non versionnes.
+# Leur absence degrade la precision sans empecher le service de repondre.
+OPTIONAL_WEIGHTS = {
+    "camembert_fr.pt": "CamemBERT FR fine-tune — etage FR de la cascade V9",
+    "camembert_fr_v2.pt": "CamemBERT FR v2 — variante textes ultra-courts",
+    "camembert_best.pt": "CamemBERT — meilleur checkpoint d'entrainement",
+    "roberta_en.pt": "RoBERTa EN fine-tune — etage EN de la cascade V9",
+    "roberta_en_v2.pt": "RoBERTa EN v2 — +4.3 % F1 vs v1",
+}
+
+# Extensions considerees comme des artefacts de modele.
+TRACKED_SUFFIXES = (".pkl", ".pt", ".joblib", ".pickle", ".json")
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _tracked_files() -> list[str]:
+    if not os.path.isdir(MODELS_DIR):
+        return []
+    return sorted(
+        name
+        for name in os.listdir(MODELS_DIR)
+        if name.endswith(TRACKED_SUFFIXES)
+        and name != os.path.basename(MANIFEST_PATH)
+        and name not in OPTIONAL_WEIGHTS
+        and os.path.isfile(os.path.join(MODELS_DIR, name))
+    )
+
+
+def build_manifest() -> dict:
+    """Construit le manifeste a partir du contenu actuel de models/."""
+    artifacts = {}
+    for name in _tracked_files():
+        path = os.path.join(MODELS_DIR, name)
+        artifacts[name] = {
+            "sha256": _sha256(path),
+            "bytes": os.path.getsize(path),
+        }
+    return {
+        "versioned_artifacts": artifacts,
+        "optional_weights": OPTIONAL_WEIGHTS,
+        "note": (
+            "Les poids listes dans optional_weights depassent la limite de "
+            "100 Mo de GitHub et ne sont pas versionnes. Leur absence place la "
+            "cascade en mode degrade — voir la section « Modeles non "
+            "versionnes » du README."
+        ),
+    }
+
+
+def load_manifest() -> dict:
+    with open(MANIFEST_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def verify() -> int:
+    """Compare le disque au manifeste. Retourne un code de sortie."""
+    if not os.path.exists(MANIFEST_PATH):
+        print(f"ERREUR: {MANIFEST_PATH} absent. Lancez `generate`.", file=sys.stderr)
+        return 1
+
+    expected = load_manifest()["versioned_artifacts"]
+    problems: list[str] = []
+
+    for name, meta in sorted(expected.items()):
+        path = os.path.join(MODELS_DIR, name)
+        if not os.path.exists(path):
+            problems.append(f"MANQUANT   {name}")
+            continue
+        actual = _sha256(path)
+        if actual != meta["sha256"]:
+            problems.append(
+                f"ALTERE     {name}\n"
+                f"           attendu {meta['sha256'][:16]}…\n"
+                f"           obtenu  {actual[:16]}…"
+            )
+
+    extras = set(_tracked_files()) - set(expected)
+    for name in sorted(extras):
+        problems.append(f"NON SUIVI  {name} (absent du manifeste)")
+
+    if problems:
+        print("Verification du manifeste — ECHEC\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            f"\n{len(problems)} ecart(s). Si le changement est voulu : "
+            "python scripts/models_manifest.py generate",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Manifeste verifie — {len(expected)} artefacts conformes.")
+    return 0
+
+
+def status() -> int:
+    """Etat lisible : ce qui est present, ce qui manque, cascade complete ou non."""
+    manifest = load_manifest() if os.path.exists(MANIFEST_PATH) else build_manifest()
+
+    versioned = manifest["versioned_artifacts"]
+    total_mb = sum(m["bytes"] for m in versioned.values()) / 1048576
+    print(f"Artefacts versionnes : {len(versioned)} ({total_mb:.1f} Mo)")
+
+    missing = []
+    print("\nPoids optionnels (non versionnes) :")
+    for name, desc in sorted(OPTIONAL_WEIGHTS.items()):
+        present = os.path.exists(os.path.join(MODELS_DIR, name))
+        print(f"  [{'x' if present else ' '}] {name:<24} {desc}")
+        if not present:
+            missing.append(name)
+
+    if missing:
+        print(f"\nCascade DEGRADEE — {len(missing)} poids absent(s).")
+        print("Le meta-learner TF-IDF et le modele d'emotions fonctionnent ;")
+        print("les etages transformer sont desactives.")
+    else:
+        print("\nCascade COMPLETE.")
+    return 0
+
+
+def generate() -> int:
+    manifest = build_manifest()
+    with open(MANIFEST_PATH, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False, sort_keys=True)
+        f.write("\n")
+    n = len(manifest["versioned_artifacts"])
+    print(f"Manifeste ecrit : {MANIFEST_PATH} ({n} artefacts)")
+    return 0
+
+
+COMMANDS = {"generate": generate, "verify": verify, "status": status}
+
+
+def main(argv: list[str]) -> int:
+    cmd = argv[1] if len(argv) > 1 else "status"
+    if cmd not in COMMANDS:
+        print(f"Commande inconnue : {cmd}", file=sys.stderr)
+        print(f"Disponibles : {', '.join(COMMANDS)}", file=sys.stderr)
+        return 2
+    return COMMANDS[cmd]()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/package_livrable.py
+++ b/scripts/package_livrable.py
@@ -64,8 +64,7 @@ def step1_generate_pdfs():
     """Regenere tous les PDF depuis les MD."""
     print("[1/4] Regeneration des PDF...")
     result = subprocess.run(
-        [sys.executable, str(DOCS_DIR / "generate_pdf.py")],
-        capture_output=True, text=True
+        [sys.executable, str(DOCS_DIR / "generate_pdf.py")], capture_output=True, text=True
     )
     if result.returncode != 0:
         print(f"  ERREUR: {result.stderr}")
@@ -83,8 +82,7 @@ def step2_assemble_groupe():
             from PyPDF2 import PdfMerger
         except ImportError:
             print("  pypdf/PyPDF2 non disponible — copie du rapport seul")
-            shutil.copy2(PDF_DIR / "rapport_projet_thumalien.pdf",
-                         OUTPUT_DIR / PDF_GROUPE)
+            shutil.copy2(PDF_DIR / "rapport_projet_thumalien.pdf", OUTPUT_DIR / PDF_GROUPE)
             return
 
     merger = PdfMerger()
@@ -125,7 +123,7 @@ def step4_create_zip():
     """Cree le ZIP final."""
     print(f"[4/4] Creation du ZIP -> {ZIP_NAME}.zip")
     zip_path = ROOT / f"{ZIP_NAME}"
-    shutil.make_archive(str(zip_path), 'zip', str(OUTPUT_DIR))
+    shutil.make_archive(str(zip_path), "zip", str(OUTPUT_DIR))
     final_size = (ROOT / f"{ZIP_NAME}.zip").stat().st_size / (1024 * 1024)
     print(f"  OK — {ZIP_NAME}.zip ({final_size:.1f} MB)")
 
@@ -143,7 +141,7 @@ def main():
     step4_create_zip()
 
     print(f"\n{'=' * 60}")
-    print(f"Contenu du ZIP :")
+    print("Contenu du ZIP :")
     for f in sorted(OUTPUT_DIR.iterdir()):
         size_kb = f.stat().st_size / 1024
         print(f"  {f.name} ({size_kb:.0f} KB)")

--- a/scripts/run_xai_pipeline.py
+++ b/scripts/run_xai_pipeline.py
@@ -59,6 +59,7 @@ log = logging.getLogger("run_xai")
 #  Helpers généraux
 # =====================================================================
 
+
 def load_gold_set() -> pd.DataFrame:
     """
     Charge le gold test set annoté. Colonnes normalisées :
@@ -121,13 +122,14 @@ def select_examples(df: pd.DataFrame, predictions: np.ndarray, k: int = 1) -> di
 #  Feature engineering : V6 (style + emotions) au vol
 # =====================================================================
 
+
 def build_v6_features(texts: pd.Series) -> tuple[np.ndarray, list]:
     """
     Construit la matrice X (n, 35) — 28 style + 7 émotions — comme dans le
     notebook 24, et renvoie aussi la liste des 35 noms de features.
     """
-    from pipeline.style_features import StyleFeatureExtractorV6
     from pipeline.expert_detector import EmotionFeatureExtractor
+    from pipeline.style_features import StyleFeatureExtractorV6
 
     X_style = StyleFeatureExtractorV6.extract(texts)
     feat_names = list(StyleFeatureExtractorV6.FEATURE_NAMES)
@@ -141,8 +143,13 @@ def build_v6_features(texts: pd.Series) -> tuple[np.ndarray, list]:
         X = np.hstack([X_style, X_emo])
         # Noms d'émotions cohérents avec le dashboard
         emo_names = [
-            "emo_anger", "emo_disgust", "emo_joy", "emo_neutral",
-            "emo_fear", "emo_surprise", "emo_sadness",
+            "emo_anger",
+            "emo_disgust",
+            "emo_joy",
+            "emo_neutral",
+            "emo_fear",
+            "emo_surprise",
+            "emo_sadness",
         ]
         feat_names += emo_names[: X_emo.shape[1]]
     else:
@@ -176,9 +183,11 @@ def compute_v5_v6_scores(
 #  Étape 1 : SHAP global sur V6
 # =====================================================================
 
+
 def step_shap_global(gold_df: pd.DataFrame) -> dict:
     log.info("[1/6] SHAP global sur V6")
     import joblib
+
     from explainability.shap_global import GlobalShapExplainer
 
     v6 = joblib.load(PROJ_ROOT / "models" / "model_style_v6.joblib")
@@ -207,10 +216,12 @@ def step_shap_global(gold_df: pd.DataFrame) -> dict:
 #  Étape 2 : Faithfulness test
 # =====================================================================
 
+
 def step_faithfulness(gold_df: pd.DataFrame) -> dict:
     log.info("[2/6] Faithfulness test sur V6")
     import joblib
     import shap
+
     from explainability.faithfulness import FaithfulnessEvaluator
 
     v6 = joblib.load(PROJ_ROOT / "models" / "model_style_v6.joblib")
@@ -241,13 +252,16 @@ def step_faithfulness(gold_df: pd.DataFrame) -> dict:
         output_dir=str(OUTPUT_DIR),
     )
     cmp = ev.compare_with_random(
-        X_in, sv,
+        X_in,
+        sv,
         n_random_seeds=5,
         max_k=min(20, X_in.shape[1]),
     )
     log.info(
         "  AOPC attribution=%.4f | random=%.4f (uplift=%+.4f)",
-        cmp["aopc_attribution"], cmp["aopc_random_mean"], cmp["aopc_uplift"],
+        cmp["aopc_attribution"],
+        cmp["aopc_random_mean"],
+        cmp["aopc_uplift"],
     )
     return {
         "aopc_attribution": cmp["aopc_attribution"],
@@ -263,6 +277,7 @@ def step_faithfulness(gold_df: pd.DataFrame) -> dict:
 #  Étape 3 : Décomposition méta-learner V8
 # =====================================================================
 
+
 def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
     """
     Calcule X_meta au vol pour le gold set, applique V8, décompose 3
@@ -270,6 +285,7 @@ def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
     """
     log.info("[3/6] Décomposition méta-learner V8")
     import joblib
+
     from explainability.meta_decomposition import MetaLearnerDecomposer
 
     v8 = joblib.load(PROJ_ROOT / "models" / "model_hybrid_v8.joblib")
@@ -299,15 +315,26 @@ def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
     min_fiable = np.minimum(score_v5, score_cam)
 
     if uses_cam:
-        X_meta = np.column_stack([
-            score_v5, score_v6, score_cam,
-            disagreement_v5_v6, disagreement_v5_cam,
-            interaction_v5_v6, min_fiable,
-        ])
+        X_meta = np.column_stack(
+            [
+                score_v5,
+                score_v6,
+                score_cam,
+                disagreement_v5_v6,
+                disagreement_v5_cam,
+                interaction_v5_v6,
+                min_fiable,
+            ]
+        )
     else:
-        X_meta = np.column_stack([
-            score_v5, score_v6, disagreement_v5_v6, interaction_v5_v6,
-        ])
+        X_meta = np.column_stack(
+            [
+                score_v5,
+                score_v6,
+                disagreement_v5_v6,
+                interaction_v5_v6,
+            ]
+        )
 
     np.save(CACHE_DIR / "X_meta_gold.npy", X_meta)
 
@@ -320,7 +347,7 @@ def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
         "feature_names": decomposer.feature_names,
         "coef": decomposer.coef.tolist(),
         "intercept": decomposer.intercept,
-        "n_samples": int(len(gold_df)),
+        "n_samples": len(gold_df),
         "samples": [],
     }
     import matplotlib.pyplot as plt
@@ -344,7 +371,7 @@ def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
             ax.set_xlabel("Contribution β·x au logit (+ = pousse vers SUSPECT)", fontsize=10)
             ax.set_title(
                 f"Décomposition V8 — {err_type} (id={i})\n"
-                f'"{ex["text"][:80]}{"..." if len(ex["text"])>80 else ""}"\n'
+                f'"{ex["text"][:80]}{"..." if len(ex["text"]) > 80 else ""}"\n'
                 f"logit z = {d.logit:+.3f} → P(suspect) = {d.proba_suspect:.3f} → {d.label}",
                 fontsize=10,
             )
@@ -354,20 +381,25 @@ def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
             plt.savefig(fig_path, dpi=150, bbox_inches="tight")
             plt.close(fig)
 
-            out["samples"].append({
-                "error_type": err_type,
-                "sample_idx": i,
-                "text": ex["text"][:160],
-                "logit": d.logit,
-                "proba_suspect": d.proba_suspect,
-                "label": d.label,
-                "ground_truth": "SUSPECT" if ex["label_int"] == 1 else "FIABLE",
-                "top_drivers": d.top_drivers(5),
-                "figure": str(fig_path),
-            })
+            out["samples"].append(
+                {
+                    "error_type": err_type,
+                    "sample_idx": i,
+                    "text": ex["text"][:160],
+                    "logit": d.logit,
+                    "proba_suspect": d.proba_suspect,
+                    "label": d.label,
+                    "ground_truth": "SUSPECT" if ex["label_int"] == 1 else "FIABLE",
+                    "top_drivers": d.top_drivers(5),
+                    "figure": str(fig_path),
+                }
+            )
             log.info(
                 "  %s id=%d → P=%.3f (%s, vrai=%s)",
-                err_type, i, d.proba_suspect, d.label,
+                err_type,
+                i,
+                d.proba_suspect,
+                d.label,
                 "SUSPECT" if ex["label_int"] == 1 else "FIABLE",
             )
     return out
@@ -376,6 +408,7 @@ def step_meta_decomposition(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
 # =====================================================================
 #  Étape 4 : Attention CamemBERT
 # =====================================================================
+
 
 def _try_load_camembert():
     """Charge CamemBERT en essayant camembert_fr (full) puis camembert_best."""
@@ -403,15 +436,21 @@ def step_attention(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
         return {"skipped": True, "reason": "camembert_not_loaded"}
 
     from explainability.attention_viz import CamembertAttentionExplainer
+
     explainer = CamembertAttentionExplainer(cam_classifier, output_dir=str(OUTPUT_DIR))
 
     # Filtre FR pour CamemBERT (heuristique simple)
     df_fr = gold_df.copy()
     # Non-capturing group (?:...) pour éviter le warning pandas sur les groupes
-    df_fr["language"] = df_fr["text"].str.contains(
-        r"\b(?:le|la|de|des|et|une|sont|avec|pour|dans|que|qui|pas|mais|c'est|n'est)\b",
-        regex=True, case=False,
-    ).map({True: "fr", False: "en"})
+    df_fr["language"] = (
+        df_fr["text"]
+        .str.contains(
+            r"\b(?:le|la|de|des|et|une|sont|avec|pour|dans|que|qui|pas|mais|c'est|n'est)\b",
+            regex=True,
+            case=False,
+        )
+        .map({True: "fr", False: "en"})
+    )
     df_fr = df_fr[df_fr["language"] == "fr"].reset_index(drop=True)
     if df_fr.empty:
         log.warning("  Aucun texte FR dans le gold — skip attention")
@@ -437,7 +476,10 @@ def step_attention(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
             }
             log.info(
                 "  %s id=%d → %s (P=%.2f)",
-                err_type, ex["id"], res.prediction_label, res.prediction_proba_suspect,
+                err_type,
+                ex["id"],
+                res.prediction_label,
+                res.prediction_proba_suspect,
             )
     return out
 
@@ -445,6 +487,7 @@ def step_attention(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
 # =====================================================================
 #  Étape 5 : Layer Integrated Gradients
 # =====================================================================
+
 
 def step_integrated_gradients(gold_df: pd.DataFrame, cam_classifier=None) -> dict:
     """
@@ -465,20 +508,26 @@ def step_integrated_gradients(gold_df: pd.DataFrame, cam_classifier=None) -> dic
         return {"skipped": True, "reason": "camembert_not_loaded"}
 
     from explainability.integrated_gradients import IGExplainer
+
     explainer = IGExplainer(
         cam_classifier,
         output_dir=str(OUTPUT_DIR),
-        n_steps=200,                    # transformers : 200 = bon compromis
+        n_steps=200,  # transformers : 200 = bon compromis
         target_class=1,
         baseline_strategy="auto",
     )
 
     # Filtre FR (heuristique simple, idem step_attention)
     df = gold_df.copy()
-    df["language"] = df["text"].str.contains(
-        r"\b(?:le|la|de|des|et|une|sont|avec|pour|dans|que|qui|pas|mais|c'est|n'est)\b",
-        regex=True, case=False,
-    ).map({True: "fr", False: "en"})
+    df["language"] = (
+        df["text"]
+        .str.contains(
+            r"\b(?:le|la|de|des|et|une|sont|avec|pour|dans|que|qui|pas|mais|c'est|n'est)\b",
+            regex=True,
+            case=False,
+        )
+        .map({True: "fr", False: "en"})
+    )
     df_fr = df[(df["language"] == "fr") & (df["text"].str.len() > 30)].reset_index(drop=True)
     if df_fr.empty:
         return {"skipped": True, "reason": "no_french_in_gold"}
@@ -534,8 +583,12 @@ def step_integrated_gradients(gold_df: pd.DataFrame, cam_classifier=None) -> dic
             }
             log.info(
                 "  %s id=%d P=%.3f target=%s Δ=%.2e completeness=%s",
-                err_type, row["id"], p_suspect[i], target_name,
-                res.convergence_delta, ok,
+                err_type,
+                row["id"],
+                p_suspect[i],
+                target_name,
+                res.convergence_delta,
+                ok,
             )
         except Exception as e:
             log.warning("  IG échoué pour id=%d : %s", row["id"], e)
@@ -625,21 +678,27 @@ def build_index(results: dict, n_gold: int) -> Path:
     comp5 = fmt(comp.get(5))
 
     meta = results.get("meta_decomposition", {})
-    meta_coefs = "\n".join(
-        f"- `{n}` : β={c:+.3f}"
-        for n, c in zip(meta.get("feature_names", []), meta.get("coef", []))
-    ) or "_(non généré)_"
+    meta_coefs = (
+        "\n".join(
+            f"- `{n}` : β={c:+.3f}"
+            for n, c in zip(meta.get("feature_names", []), meta.get("coef", []))
+        )
+        or "_(non généré)_"
+    )
     meta_intercept = meta.get("intercept")
     if isinstance(meta_intercept, (int, float)):
         meta_coefs += f"\n- `intercept` : β₀={meta_intercept:+.3f}"
 
-    meta_samples = "\n".join(
-        f"- **{s['error_type']}** id={s['sample_idx']} → "
-        f"P(suspect)={s['proba_suspect']:.3f} ({s['label']}, vrai={s['ground_truth']}) — "
-        f"top contributeur : `{s['top_drivers'][0]['feature']}` "
-        f"({s['top_drivers'][0]['contribution']:+.3f})"
-        for s in meta.get("samples", [])
-    ) or "_(non généré)_"
+    meta_samples = (
+        "\n".join(
+            f"- **{s['error_type']}** id={s['sample_idx']} → "
+            f"P(suspect)={s['proba_suspect']:.3f} ({s['label']}, vrai={s['ground_truth']}) — "
+            f"top contributeur : `{s['top_drivers'][0]['feature']}` "
+            f"({s['top_drivers'][0]['contribution']:+.3f})"
+            for s in meta.get("samples", [])
+        )
+        or "_(non généré)_"
+    )
 
     attn = results.get("attention", {})
     attn_rows_list = []
@@ -647,17 +706,19 @@ def build_index(results: dict, n_gold: int) -> Path:
         info = attn.get(k)
         if isinstance(info, dict) and "figures" in info:
             fig = os.path.basename(info["figures"].get("heatmap", ""))
-            attn_rows_list.append(
-                f"| {k} | {info.get('p_suspect', 0):.3f} | `{fig}` |"
-            )
-    attn_rows = "\n".join(attn_rows_list) or \
-        "_(non généré — `transformers` ou modèle CamemBERT manquant)_"
+            attn_rows_list.append(f"| {k} | {info.get('p_suspect', 0):.3f} | `{fig}` |")
+    attn_rows = (
+        "\n".join(attn_rows_list) or "_(non généré — `transformers` ou modèle CamemBERT manquant)_"
+    )
 
     def _ig_level(d):
         a = abs(d)
-        if a < 0.01: return "✓ axiomatique"
-        if a < 0.05: return "✓ pratique"
-        if a < 0.15: return "~ indicatif"
+        if a < 0.01:
+            return "✓ axiomatique"
+        if a < 0.05:
+            return "✓ pratique"
+        if a < 0.15:
+            return "~ indicatif"
         return "✗ rejet"
 
     ig = results.get("integrated_gradients", {})
@@ -670,18 +731,22 @@ def build_index(results: dict, n_gold: int) -> Path:
         delta = info.get("convergence_delta", 0)
         target = info.get("target_explained", "?")
         ig_rows_list.append(
-            f"| {sid} | {p:.3f} | {target} | {delta:+.2e} | "
-            f"{_ig_level(delta)} | `{fig}` |"
+            f"| {sid} | {p:.3f} | {target} | {delta:+.2e} | {_ig_level(delta)} | `{fig}` |"
         )
-    ig_rows = "\n".join(ig_rows_list) or \
-        "_(non généré — `captum` ou modèle manquant)_"
+    ig_rows = "\n".join(ig_rows_list) or "_(non généré — `captum` ou modèle manquant)_"
 
     md = INDEX_TEMPLATE.format(
-        date=date.today().isoformat(), n_gold=n_gold,
-        aopc_attr=aopc_attr, aopc_rand=aopc_rand, uplift=uplift,
-        comp1=comp1, comp5=comp5,
-        meta_coefs=meta_coefs, meta_samples=meta_samples,
-        attn_rows=attn_rows, ig_rows=ig_rows,
+        date=date.today().isoformat(),
+        n_gold=n_gold,
+        aopc_attr=aopc_attr,
+        aopc_rand=aopc_rand,
+        uplift=uplift,
+        comp1=comp1,
+        comp5=comp5,
+        meta_coefs=meta_coefs,
+        meta_samples=meta_samples,
+        attn_rows=attn_rows,
+        ig_rows=ig_rows,
     )
     path = OUTPUT_DIR / "INDEX.md"
     path.write_text(md, encoding="utf-8")
@@ -693,10 +758,13 @@ def build_index(results: dict, n_gold: int) -> Path:
 #  Main
 # =====================================================================
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--skip", action="append", default=[],
+        "--skip",
+        action="append",
+        default=[],
         choices=["shap", "faithfulness", "meta", "attention", "ig"],
         help="Étapes à sauter (peut être répété).",
     )
@@ -704,9 +772,12 @@ def main():
 
     t0 = time.time()
     gold = load_gold_set()
-    log.info("Gold set chargé : %d posts (%d suspects, %d fiables)",
-             len(gold), int((gold["label_int"] == 1).sum()),
-             int((gold["label_int"] == 0).sum()))
+    log.info(
+        "Gold set chargé : %d posts (%d suspects, %d fiables)",
+        len(gold),
+        int((gold["label_int"] == 1).sum()),
+        int((gold["label_int"] == 0).sum()),
+    )
 
     # CamemBERT chargé une seule fois (réutilisé par méta + attention + IG)
     cam_clf = None

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import pandas as pd
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -38,6 +38,9 @@ EMOTION_LABELS = ["colere", "degout", "joie", "neutre", "peur", "surprise", "tri
 # ---------------------------------------------------------------------------
 detector: ExpertFakeNewsDetector | None = None
 emotion_extractor: EmotionFeatureExtractor | None = None
+# Suffixe du modele effectivement charge — expose par /version pour tracer
+# quelle version sert le trafic (verification de deploiement / rollback).
+_loaded_model_suffix: str | None = None
 
 # Cumulative energy metrics for the API session
 _energy_metrics: dict[str, Any] = {
@@ -115,6 +118,8 @@ def _load_detector() -> ExpertFakeNewsDetector | None:
             try:
                 det = ExpertFakeNewsDetector(model_dir=model_dir)
                 det.load(suffix=suffix)
+                global _loaded_model_suffix
+                _loaded_model_suffix = suffix
                 logger.info("Model loaded: %s", suffix)
                 return det
             except Exception:
@@ -264,6 +269,33 @@ class HealthResponse(BaseModel):
     cascade_missing: list[str]
 
 
+class VersionResponse(BaseModel):
+    """Identite exacte de l'instance servie.
+
+    Indispensable pour verifier un deploiement ou un rollback : sans cela on
+    ne peut pas savoir quelle revision et quel modele repondent reellement.
+    """
+
+    api_version: str
+    git_sha: str
+    model_suffix: str | None
+    cascade_full: bool
+    build_time: str | None
+
+
+class ReadyResponse(BaseModel):
+    """Sonde de disponibilite, distincte de /health (vivacite).
+
+    /health repond des que le processus tourne ; /ready ne repond 200 que si
+    l'instance peut reellement servir une prediction. Un orchestrateur doit
+    router le trafic sur /ready, sinon il envoie des requetes a une instance
+    dont le modele n'est pas encore charge.
+    """
+
+    ready: bool
+    reason: str | None
+
+
 # ---------------------------------------------------------------------------
 #  Endpoints
 # ---------------------------------------------------------------------------
@@ -278,6 +310,27 @@ def health() -> HealthResponse:
         cascade_full=not missing,
         cascade_missing=missing,
     )
+
+
+@app.get("/version", response_model=VersionResponse)
+def version() -> VersionResponse:
+    """Revision, modele et etat de cascade de l'instance servie."""
+    return VersionResponse(
+        api_version=app.version,
+        git_sha=os.environ.get("GIT_SHA", "unknown"),
+        model_suffix=_loaded_model_suffix,
+        cascade_full=not _missing_cascade_models(),
+        build_time=os.environ.get("BUILD_TIME"),
+    )
+
+
+@app.get("/ready", response_model=ReadyResponse)
+def ready(response: Response) -> ReadyResponse:
+    """503 tant que l'instance ne peut pas servir de prediction."""
+    if detector is None:
+        response.status_code = 503
+        return ReadyResponse(ready=False, reason="model_not_loaded")
+    return ReadyResponse(ready=True, reason=None)
 
 
 @app.get("/energy", response_model=EnergyResponse)

--- a/tests/test_api_deployment.py
+++ b/tests/test_api_deployment.py
@@ -1,0 +1,94 @@
+"""
+Tests des endpoints d'exploitation : /version et /ready.
+
+Ces deux endpoints rendent un deploiement pilotable :
+- /version identifie la revision et le modele qui servent reellement le trafic
+  (verification d'un deploiement, constat d'un rollback) ;
+- /ready distingue « le processus tourne » de « l'instance peut repondre ».
+  Un orchestrateur qui route sur /health envoie du trafic a une instance dont
+  le modele n'est pas charge.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from api import main as api_main
+from api.main import app
+
+
+class TestVersionEndpoint:
+    def test_returns_200_without_model(self):
+        """/version doit repondre meme si aucun modele n'est charge."""
+        with patch.object(api_main, "detector", None):
+            r = TestClient(app).get("/version")
+        assert r.status_code == 200
+
+    def test_exposes_api_version(self):
+        r = TestClient(app).get("/version")
+        assert r.json()["api_version"] == app.version
+
+    def test_git_sha_falls_back_to_unknown(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GIT_SHA", None)
+            r = TestClient(app).get("/version")
+        assert r.json()["git_sha"] == "unknown"
+
+    def test_git_sha_read_from_environment(self):
+        with patch.dict(os.environ, {"GIT_SHA": "abc1234"}):
+            r = TestClient(app).get("/version")
+        assert r.json()["git_sha"] == "abc1234"
+
+    def test_build_time_read_from_environment(self):
+        with patch.dict(os.environ, {"BUILD_TIME": "2026-08-02T10:00:00Z"}):
+            r = TestClient(app).get("/version")
+        assert r.json()["build_time"] == "2026-08-02T10:00:00Z"
+
+    def test_model_suffix_reflects_loaded_model(self):
+        with patch.object(api_main, "_loaded_model_suffix", "expert_v5"):
+            r = TestClient(app).get("/version")
+        assert r.json()["model_suffix"] == "expert_v5"
+
+    def test_cascade_full_false_when_weights_missing(self, tmp_path):
+        """Poids transformer absents : la cascade est signalee incomplete."""
+        with patch.dict(os.environ, {"THUMALIEN_MODEL_DIR": str(tmp_path)}):
+            r = TestClient(app).get("/version")
+        assert r.json()["cascade_full"] is False
+
+    def test_cascade_full_true_when_weights_present(self, tmp_path):
+        (tmp_path / "camembert_fr.pt").write_bytes(b"x")
+        (tmp_path / "roberta_en.pt").write_bytes(b"x")
+        with patch.dict(os.environ, {"THUMALIEN_MODEL_DIR": str(tmp_path)}):
+            r = TestClient(app).get("/version")
+        assert r.json()["cascade_full"] is True
+
+    def test_response_shape_is_stable(self):
+        """Le contrat est consomme par l'outillage de deploiement."""
+        keys = set(TestClient(app).get("/version").json())
+        assert keys == {"api_version", "git_sha", "model_suffix", "cascade_full", "build_time"}
+
+
+class TestReadyEndpoint:
+    def test_503_when_model_not_loaded(self):
+        with patch.object(api_main, "detector", None):
+            r = TestClient(app).get("/ready")
+        assert r.status_code == 503
+        assert r.json()["ready"] is False
+        assert r.json()["reason"] == "model_not_loaded"
+
+    def test_200_when_model_loaded(self):
+        with patch.object(api_main, "detector", object()):
+            r = TestClient(app).get("/ready")
+        assert r.status_code == 200
+        assert r.json()["ready"] is True
+        assert r.json()["reason"] is None
+
+    def test_differs_from_health_when_degraded(self):
+        """/health repond 200 (le process vit) alors que /ready refuse le trafic."""
+        with patch.object(api_main, "detector", None):
+            c = TestClient(app)
+            assert c.get("/health").status_code == 200
+            assert c.get("/ready").status_code == 503

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -50,7 +50,7 @@ class TestRunProxy:
 
     def test_log_metrics_forwards_each_key(self):
         fake = MagicMock()
-        with patch.object(mlflow_tracker, "mlflow", fake):
+        with patch.object(mlflow_tracker, "mlflow", fake, create=True):
             _RunProxy(MagicMock()).log_metrics({"f1": 0.913, "accuracy": 0.91})
         assert fake.log_metric.call_count == 2
         fake.log_metric.assert_any_call("f1", 0.913)
@@ -59,14 +59,14 @@ class TestRunProxy:
     def test_log_params_stringifies_values(self):
         """log_param recoit des chaines : MLFlow refuse certains types natifs."""
         fake = MagicMock()
-        with patch.object(mlflow_tracker, "mlflow", fake):
+        with patch.object(mlflow_tracker, "mlflow", fake, create=True):
             _RunProxy(MagicMock()).log_params({"C": 1.0, "solver": "lbfgs"})
         fake.log_param.assert_any_call("C", "1.0")
         fake.log_param.assert_any_call("solver", "lbfgs")
 
     def test_log_artifact_skips_missing_file(self):
         fake = MagicMock()
-        with patch.object(mlflow_tracker, "mlflow", fake):
+        with patch.object(mlflow_tracker, "mlflow", fake, create=True):
             _RunProxy(MagicMock()).log_artifact("/chemin/vraiment/inexistant.pkl")
         fake.log_artifact.assert_not_called()
 
@@ -74,7 +74,7 @@ class TestRunProxy:
         artefact = tmp_path / "model.pkl"
         artefact.write_bytes(b"contenu")
         fake = MagicMock()
-        with patch.object(mlflow_tracker, "mlflow", fake):
+        with patch.object(mlflow_tracker, "mlflow", fake, create=True):
             _RunProxy(MagicMock()).log_artifact(str(artefact))
         fake.log_artifact.assert_called_once_with(str(artefact))
 
@@ -85,7 +85,7 @@ class TestRunProxy:
 
     def test_empty_metrics_forwards_nothing(self):
         fake = MagicMock()
-        with patch.object(mlflow_tracker, "mlflow", fake):
+        with patch.object(mlflow_tracker, "mlflow", fake, create=True):
             _RunProxy(MagicMock()).log_metrics({})
         fake.log_metric.assert_not_called()
 
@@ -104,7 +104,7 @@ class TestTrackExperiment:
     def test_sets_tracking_uri_and_experiment(self):
         fake = self._fake_mlflow()
         with (
-            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "mlflow", fake, create=True),
             patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
         ):
             with track_experiment("V5_TF-IDF_LogReg"):
@@ -116,7 +116,7 @@ class TestTrackExperiment:
     def test_run_name_is_passed_through(self):
         fake = self._fake_mlflow()
         with (
-            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "mlflow", fake, create=True),
             patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
         ):
             with track_experiment("mon_run"):
@@ -126,7 +126,7 @@ class TestTrackExperiment:
     def test_params_logged_before_body_runs(self):
         fake = self._fake_mlflow()
         with (
-            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "mlflow", fake, create=True),
             patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
         ):
             with track_experiment("run", params={"C": 1.0, "max_iter": 500}):
@@ -137,7 +137,7 @@ class TestTrackExperiment:
     def test_yields_run_proxy_with_id(self):
         fake = self._fake_mlflow()
         with (
-            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "mlflow", fake, create=True),
             patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
         ):
             with track_experiment("run") as proxy:
@@ -147,7 +147,7 @@ class TestTrackExperiment:
     def test_metrics_logged_from_body(self):
         fake = self._fake_mlflow()
         with (
-            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "mlflow", fake, create=True),
             patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
         ):
             with track_experiment("run") as proxy:
@@ -158,7 +158,7 @@ class TestTrackExperiment:
         """Une erreur d'entrainement ne doit pas etre avalee par le tracker."""
         fake = self._fake_mlflow()
         with (
-            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "mlflow", fake, create=True),
             patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
         ):
             with pytest.raises(ValueError, match="echec entrainement"):

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -1,0 +1,177 @@
+"""
+Tests du tracker MLFlow.
+
+Ce module etait a 0 % de couverture — la seule brique MLOps du depot n'etait
+pas testee. Les tests couvrent les deux chemins : MLFlow disponible (via mock,
+aucun serveur requis) et MLFlow absent (fallback silencieux).
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from monitoring import mlflow_tracker
+from monitoring.mlflow_tracker import _NoopProxy, _RunProxy, track_experiment
+
+
+class TestNoopProxy:
+    """MLFlow absent : le tracker ne doit jamais faire echouer un entrainement."""
+
+    def test_log_metrics_is_silent(self):
+        assert _NoopProxy().log_metrics({"f1": 0.9}) is None
+
+    def test_log_params_is_silent(self):
+        assert _NoopProxy().log_params({"C": 1.0}) is None
+
+    def test_log_artifact_is_silent(self):
+        assert _NoopProxy().log_artifact("/chemin/inexistant.pkl") is None
+
+    def test_run_id_is_noop(self):
+        assert _NoopProxy().run_id == "noop"
+
+    def test_context_manager_yields_noop_when_unavailable(self):
+        with patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", False):
+            with track_experiment("run_test") as run:
+                assert isinstance(run, _NoopProxy)
+                run.log_metrics({"f1": 0.9})  # ne doit pas lever
+
+    def test_params_ignored_when_unavailable(self):
+        """Les params passes au context manager ne doivent pas lever non plus."""
+        with patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", False):
+            with track_experiment("run_test", params={"C": 1.0}) as run:
+                assert run.run_id == "noop"
+
+
+class TestRunProxy:
+    """MLFlow disponible : chaque appel doit etre relaye a l'API mlflow."""
+
+    def test_log_metrics_forwards_each_key(self):
+        fake = MagicMock()
+        with patch.object(mlflow_tracker, "mlflow", fake):
+            _RunProxy(MagicMock()).log_metrics({"f1": 0.913, "accuracy": 0.91})
+        assert fake.log_metric.call_count == 2
+        fake.log_metric.assert_any_call("f1", 0.913)
+        fake.log_metric.assert_any_call("accuracy", 0.91)
+
+    def test_log_params_stringifies_values(self):
+        """log_param recoit des chaines : MLFlow refuse certains types natifs."""
+        fake = MagicMock()
+        with patch.object(mlflow_tracker, "mlflow", fake):
+            _RunProxy(MagicMock()).log_params({"C": 1.0, "solver": "lbfgs"})
+        fake.log_param.assert_any_call("C", "1.0")
+        fake.log_param.assert_any_call("solver", "lbfgs")
+
+    def test_log_artifact_skips_missing_file(self):
+        fake = MagicMock()
+        with patch.object(mlflow_tracker, "mlflow", fake):
+            _RunProxy(MagicMock()).log_artifact("/chemin/vraiment/inexistant.pkl")
+        fake.log_artifact.assert_not_called()
+
+    def test_log_artifact_forwards_existing_file(self, tmp_path):
+        artefact = tmp_path / "model.pkl"
+        artefact.write_bytes(b"contenu")
+        fake = MagicMock()
+        with patch.object(mlflow_tracker, "mlflow", fake):
+            _RunProxy(MagicMock()).log_artifact(str(artefact))
+        fake.log_artifact.assert_called_once_with(str(artefact))
+
+    def test_run_id_reads_mlflow_run_info(self):
+        run = MagicMock()
+        run.info.run_id = "abc123"
+        assert _RunProxy(run).run_id == "abc123"
+
+    def test_empty_metrics_forwards_nothing(self):
+        fake = MagicMock()
+        with patch.object(mlflow_tracker, "mlflow", fake):
+            _RunProxy(MagicMock()).log_metrics({})
+        fake.log_metric.assert_not_called()
+
+
+class TestTrackExperiment:
+    """Cycle complet du context manager avec MLFlow mocke."""
+
+    @staticmethod
+    def _fake_mlflow():
+        fake = MagicMock()
+        run = MagicMock()
+        run.info.run_id = "run-42"
+        fake.start_run.return_value.__enter__.return_value = run
+        return fake
+
+    def test_sets_tracking_uri_and_experiment(self):
+        fake = self._fake_mlflow()
+        with (
+            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
+        ):
+            with track_experiment("V5_TF-IDF_LogReg"):
+                pass
+        fake.set_tracking_uri.assert_called_once()
+        assert fake.set_tracking_uri.call_args[0][0].startswith("file://")
+        fake.set_experiment.assert_called_once_with(mlflow_tracker.EXPERIMENT_NAME)
+
+    def test_run_name_is_passed_through(self):
+        fake = self._fake_mlflow()
+        with (
+            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
+        ):
+            with track_experiment("mon_run"):
+                pass
+        fake.start_run.assert_called_once_with(run_name="mon_run")
+
+    def test_params_logged_before_body_runs(self):
+        fake = self._fake_mlflow()
+        with (
+            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
+        ):
+            with track_experiment("run", params={"C": 1.0, "max_iter": 500}):
+                pass
+        fake.log_param.assert_any_call("C", "1.0")
+        fake.log_param.assert_any_call("max_iter", "500")
+
+    def test_yields_run_proxy_with_id(self):
+        fake = self._fake_mlflow()
+        with (
+            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
+        ):
+            with track_experiment("run") as proxy:
+                assert isinstance(proxy, _RunProxy)
+                assert proxy.run_id == "run-42"
+
+    def test_metrics_logged_from_body(self):
+        fake = self._fake_mlflow()
+        with (
+            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
+        ):
+            with track_experiment("run") as proxy:
+                proxy.log_metrics({"f1": 0.913})
+        fake.log_metric.assert_called_once_with("f1", 0.913)
+
+    def test_exception_in_body_propagates(self):
+        """Une erreur d'entrainement ne doit pas etre avalee par le tracker."""
+        fake = self._fake_mlflow()
+        with (
+            patch.object(mlflow_tracker, "mlflow", fake),
+            patch.object(mlflow_tracker, "MLFLOW_AVAILABLE", True),
+        ):
+            with pytest.raises(ValueError, match="echec entrainement"):
+                with track_experiment("run"):
+                    raise ValueError("echec entrainement")
+
+
+class TestModuleContract:
+    def test_experiment_name_is_defined(self):
+        assert mlflow_tracker.EXPERIMENT_NAME == "ThumaCheck"
+
+    def test_tracking_uri_points_to_mlruns(self):
+        assert mlflow_tracker.TRACKING_URI.endswith("mlruns")
+
+    def test_availability_flag_is_boolean(self):
+        assert isinstance(mlflow_tracker.MLFLOW_AVAILABLE, bool)

--- a/tests/test_models_manifest.py
+++ b/tests/test_models_manifest.py
@@ -1,0 +1,137 @@
+"""
+Tests du manifeste d'artefacts.
+
+Le manifeste rend la reproductibilite verifiable : il fige l'empreinte SHA-256
+de chaque artefact versionne et documente les poids volontairement absents.
+La CI l'execute, ce qui detecte tout artefact altere ou ajoute sans suivi.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "models_manifest.py")
+_spec = importlib.util.spec_from_file_location("models_manifest", SCRIPT)
+assert _spec and _spec.loader
+mm = importlib.util.module_from_spec(_spec)
+sys.modules["models_manifest"] = mm
+_spec.loader.exec_module(mm)
+
+
+@pytest.fixture
+def fake_models(tmp_path, monkeypatch):
+    """Repertoire models/ isole avec deux artefacts connus."""
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / "model_test.pkl").write_bytes(b"contenu-a")
+    (models / "metrics_test.pkl").write_bytes(b"contenu-b")
+    monkeypatch.setattr(mm, "MODELS_DIR", str(models))
+    monkeypatch.setattr(mm, "MANIFEST_PATH", str(models / "MANIFEST.json"))
+    return models
+
+
+class TestBuildManifest:
+    def test_lists_tracked_artifacts(self, fake_models):
+        m = mm.build_manifest()
+        assert set(m["versioned_artifacts"]) == {"model_test.pkl", "metrics_test.pkl"}
+
+    def test_records_sha256_and_size(self, fake_models):
+        entry = mm.build_manifest()["versioned_artifacts"]["model_test.pkl"]
+        assert len(entry["sha256"]) == 64
+        assert entry["bytes"] == len(b"contenu-a")
+
+    def test_ignores_non_artifact_extensions(self, fake_models):
+        (fake_models / "notes.txt").write_text("hors perimetre")
+        assert "notes.txt" not in mm.build_manifest()["versioned_artifacts"]
+
+    def test_optional_weights_excluded_from_artifacts(self, fake_models):
+        """Un poids optionnel present ne doit pas entrer dans les artefacts suivis."""
+        (fake_models / "roberta_en.pt").write_bytes(b"gros-fichier")
+        assert "roberta_en.pt" not in mm.build_manifest()["versioned_artifacts"]
+
+    def test_optional_weights_are_documented(self, fake_models):
+        assert "roberta_en.pt" in mm.build_manifest()["optional_weights"]
+
+    def test_empty_models_dir_yields_empty_manifest(self, tmp_path, monkeypatch):
+        empty = tmp_path / "vide"
+        empty.mkdir()
+        monkeypatch.setattr(mm, "MODELS_DIR", str(empty))
+        assert mm.build_manifest()["versioned_artifacts"] == {}
+
+
+class TestVerify:
+    def test_passes_on_freshly_generated_manifest(self, fake_models, capsys):
+        mm.generate()
+        assert mm.verify() == 0
+
+    def test_detects_altered_artifact(self, fake_models, capsys):
+        mm.generate()
+        (fake_models / "model_test.pkl").write_bytes(b"contenu-modifie")
+        assert mm.verify() == 1
+        assert "ALTERE" in capsys.readouterr().err
+
+    def test_detects_missing_artifact(self, fake_models, capsys):
+        mm.generate()
+        (fake_models / "model_test.pkl").unlink()
+        assert mm.verify() == 1
+        assert "MANQUANT" in capsys.readouterr().err
+
+    def test_detects_untracked_artifact(self, fake_models, capsys):
+        mm.generate()
+        (fake_models / "model_surprise.pkl").write_bytes(b"nouveau")
+        assert mm.verify() == 1
+        assert "NON SUIVI" in capsys.readouterr().err
+
+    def test_fails_when_manifest_absent(self, fake_models, capsys):
+        assert mm.verify() == 1
+        assert "absent" in capsys.readouterr().err
+
+
+class TestGenerateAndStatus:
+    def test_generate_writes_valid_json(self, fake_models):
+        mm.generate()
+        data = json.loads((fake_models / "MANIFEST.json").read_text(encoding="utf-8"))
+        assert "versioned_artifacts" in data
+        assert "optional_weights" in data
+
+    def test_generate_is_deterministic(self, fake_models):
+        mm.generate()
+        first = (fake_models / "MANIFEST.json").read_text(encoding="utf-8")
+        mm.generate()
+        assert (fake_models / "MANIFEST.json").read_text(encoding="utf-8") == first
+
+    def test_status_reports_degraded_cascade(self, fake_models, capsys):
+        assert mm.status() == 0
+        assert "DEGRADEE" in capsys.readouterr().out
+
+    def test_status_reports_complete_cascade(self, fake_models, capsys):
+        for name in mm.OPTIONAL_WEIGHTS:
+            (fake_models / name).write_bytes(b"x")
+        mm.status()
+        assert "COMPLETE" in capsys.readouterr().out
+
+
+class TestCli:
+    def test_unknown_command_returns_2(self, capsys):
+        assert mm.main(["prog", "inexistante"]) == 2
+
+    def test_defaults_to_status(self, fake_models, capsys):
+        assert mm.main(["prog"]) == 0
+        assert "Artefacts versionnes" in capsys.readouterr().out
+
+
+class TestRealRepository:
+    """Le manifeste reel du depot doit etre a jour."""
+
+    def test_repo_manifest_is_current(self):
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "verify"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Traite les manques identifiés en revue, dans la mesure du possible sans infrastructure externe.

## CD — *était : aucun pipeline de déploiement*

`.github/workflows/release.yml` construit l'image de l'API et la publie sur **GHCR** à chaque push sur `main` (tags `main`, `sha-<court>`) et sur tag git (semver + `latest`).

Un job **smoke-test** démarre ensuite l'image *publiée*, attend `/health` et vérifie que `/version` annonce bien la révision attendue. Une image cassée n'atteint pas un déploiement.

## Observabilité de déploiement — *était : ni rollback ni vérification possible*

| Endpoint | Rôle |
|---|---|
| `/version` | `api_version`, `git_sha`, modèle chargé, état de cascade, date de build |
| `/ready` | **503** tant que le modèle n'est pas chargé — distinct de `/health` (vivacité) |

La distinction compte : un orchestrateur qui route sur `/health` envoie du trafic à une instance incapable de répondre. Le `HEALTHCHECK` de l'image sonde désormais `/ready`.

Sans `/version`, impossible de savoir quelle révision sert le trafic — donc impossible de vérifier un déploiement ou un rollback.

## Reproductibilité — *était : aucun moyen de vérifier les artefacts*

`scripts/models_manifest.py` fige l'empreinte SHA-256 et la taille des **29 artefacts versionnés** dans `models/MANIFEST.json`, et documente les **5 poids volontairement absents** (> 100 Mo).

```
python scripts/models_manifest.py status   # cascade complète ou dégradée
python scripts/models_manifest.py verify   # exécuté par la CI
```

Tout artefact altéré, supprimé ou ajouté sans suivi fait échouer le build.

## Couverture MLOps — *était : `mlflow_tracker.py` à 0 %*

21 tests couvrant les deux chemins : MLFlow disponible (mocké, aucun serveur requis) et absent (fallback silencieux). Le module passe à **100 %**.

## Bilan

| | Avant | Après |
|---|---|---|
| Tests | 575 | **626** |
| Couverture | 79,7 % | **82,0 %** |
| `mlflow_tracker.py` | 0 % | **100 %** |
| Workflows | 2 | **3** |

## Non traité, faute de ressources externes

- **Déploiement effectif** vers un hébergeur — nécessite des identifiants
- **Publication des poids** CamemBERT/RoBERTa — absents du disque, je ne peux pas publier ce que je n'ai pas
- **Étude de transfert hors domaine** — nécessite de nouveaux jeux de données et du calcul

## Vérifié localement

```
ruff check          → All checks passed
ruff format --check → 72 files already formatted
mypy                → Success: no issues found in 33 source files
pytest              → 626 passed, 1 skipped
coverage            → 82,0 % (barrière 78 %)
docker build --check → Check complete, no warnings found
YAML des 4 workflows → valide
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)