### PR TITLE
fix: l'image Docker ne pouvait ni démarrer ni prédire

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,8 +9,14 @@ __pycache__/
 .github/
 .Trash-0/
 emissions.csv*
-models/*.pt
-models/*.pkl
+# Les modeles entrainés (15 Mo au total) DOIVENT etre embarques : sans eux
+# l'image demarre mais ne peut servir aucune prediction (/ready -> 503).
+# Seuls les poids transformer (> 100 Mo, non versionnes) sont exclus.
+models/camembert_best.pt
+models/camembert_fr.pt
+models/camembert_fr_v2.pt
+models/roberta_en.pt
+models/roberta_en_v2.pt
 notebooks/*.ipynb
 docs/pdf/
 *.bak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,18 +87,34 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$(echo ${{ github.sha }} | cut -c1-7) \
             uvicorn src.api.main:app --host 0.0.0.0 --port 8000
 
-      - name: Wait for /health
+      # Sonde /ready et non /health : /health repond 200 des que le processus
+      # vit, meme sans aucun modele. Une image incapable de predire passerait
+      # donc le test — c'est arrive.
+      - name: Wait for /ready
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
-              echo "API en ligne apres ${i}0s"
+            if curl -fsS http://localhost:8000/ready >/dev/null 2>&1; then
+              echo "Instance prete apres ${i}0s"
               exit 0
             fi
             sleep 10
           done
-          echo "::error::L'API n'a pas repondu sur /health en 300 s"
-          docker logs thumacheck-api
+          echo "::error::L'API n'est pas devenue prete en 300 s"
+          echo "--- /health ---"; curl -s http://localhost:8000/health || true
+          echo "--- logs ---";    docker logs thumacheck-api
           exit 1
+
+      - name: Check the image can actually predict
+        run: |
+          set -o pipefail
+          label=$(curl -fsS -X POST http://localhost:8000/predict \
+            -H 'Content-Type: application/json' \
+            -d '{"text":"SCANDALE: le gouvernement cache la VERITE!"}' | jq -r .label)
+          echo "label rendu : $label"
+          [ -n "$label" ] && [ "$label" != "null" ] || {
+            echo "::error::/predict n'a pas rendu de label"
+            exit 1
+          }
 
       - name: Check /version reports the deployed revision
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ ENV GIT_SHA=${GIT_SHA} \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
+# Les modules internes s'importent par leur nom court (`from pipeline...`).
+# En test, pytest le permet via `pythonpath` dans pyproject.toml ; dans le
+# conteneur rien ne le fournissait — l'API ne pouvait pas demarrer du tout.
+ENV PYTHONPATH=/app/src
+
 # Dossier de travail dans le conteneur
 WORKDIR /app
 


### PR DESCRIPTION
Deux défauts de déploiement **préexistants**, révélés par le premier passage du smoke-test de `release.yml`.

## 1. `PYTHONPATH` absent — l'API ne démarrait pas du tout

```
File "/app/src/api/main.py", line 22
    from pipeline.expert_detector import ...
ModuleNotFoundError: No module named 'pipeline'
```

Les modules internes s'importent par leur nom court. pytest le permet via `pythonpath` dans `pyproject.toml` ; dans le conteneur, **rien ne le fournissait**. L'image n'a jamais pu servir l'API depuis qu'elle existe.

→ `ENV PYTHONPATH=/app/src`

## 2. `.dockerignore` excluait les modèles — l'image ne pouvait rien prédire

`models/*.pt` et `models/*.pkl` étaient exclus du contexte de build. L'image démarrait, mais `/health` rendait `model_loaded: false`.

Les modèles entraînés pèsent **15 Mo au total** et sont versionnés : ils doivent être embarqués. Seuls les poids transformer (> 100 Mo, non versionnés) restent exclus — désormais nommés un à un plutôt que par joker.

## 3. Le smoke-test était trop faible pour détecter le point 2

Il sondait `/health`, qui rend 200 dès que le processus vit — **même sans aucun modèle**. Une image incapable de prédire aurait donc été validée.

Il sonde maintenant `/ready` (503 tant que le modèle n'est pas chargé) et appelle `/predict` pour vérifier qu'un label est réellement rendu.

## Vérifié par construction et démarrage effectifs en local

```
/ready   → 200 {"ready": true, "reason": null}
/health  → model_loaded: true, emotions_loaded: true
/version → model_suffix: "expert_v5", git_sha remonté correctement
/predict → {"score": 0.001, "label": "suspect", "language": "fr",
            "emotions": {"neutre": 0.8165, "surprise": 0.1382, ...}}
```

Cette fois l'image a réellement été construite et démarrée, pas seulement validée par `docker build --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)